### PR TITLE
Add definition for DNS-SD service type

### DIFF
--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -1,0 +1,32 @@
+# Discovery
+
+_(c) AMWA 2019, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
+
+NMOS Discovery makes use of the DNS Service Discovery protocol as described in [RFC 6763](https://tools.ietf.org/html/rfc6763). DNS-SD specifies a mechanism for the use of Unicast or Multicast DNS for the purpose of identifying one or more endpoints on a network associated with a named service.
+
+One DNS-SD service type is defined by this specification:
+
+* **\_nmos-auth.\_tcp:** A logical host which advertises an Authorization API.
+
+## DNS-SD Advertisement
+
+The preferred method of Authorization API advertisement is via unicast DNS-SD advertisement of the type \_nmos-auth.\_tcp. Authorization APIs MUST additionally be capable of producing an mDNS advertisement. This MAY be disabled via a user-configurable method.
+
+The IP address and port of the Authorization API MUST be identified via the DNS-SD advertisement, with the full HTTP path then being resolved via the standard NMOS API path documentation.
+
+Multiple DNS-SD advertisements for the same API are permitted where the API is exposed via multiple ports and/or protocols.
+
+## DNS-SD TXT Records
+
+**api\_proto**
+
+The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_proto' with a value of either 'http' or 'https' dependent on the protocol in use by the Authorization API web server. In production environments this MUST be set to 'https'.
+
+**api\_ver**
+
+The DNS-SD advertisement MUST be accompanied by a TXT record of name 'api\_ver'. The value of this TXT record is a comma separated list of API versions supported by the server. For example: 'v1.0,v1.1,v2.0'. There should be no whitespace between commas, and versions should be listed in ascending order.
+
+**pri**
+
+The DNS-SD advertisement MUST include a TXT record with key 'pri' and an integer value. Servers MAY additionally represent a matching priority via the DNS-SD SRV record 'priority' and 'weight' as defined in RFC 2782. The TXT record should be used in favour to the SRV priority and weight where these values differ in order to overcome issues in the Bonjour and Avahi implementations.
+Values 0 to 99 correspond to an active NMOS Authorization API (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.


### PR DESCRIPTION
Resolves #1 

This is currently noted as section 3 of the documentation, copying from the IS-04 spec. Other docs pages still need to be created which are likely to fill the gap.