### PR TITLE
[IS-10] Alter Private Claim Syntax and add JWT schema

### DIFF
--- a/APIs/AuthorizationAPI.raml
+++ b/APIs/AuthorizationAPI.raml
@@ -4,8 +4,8 @@
 # (c) AMWA 2020
 
 title: NMOS Authorization
-baseUri: http://api.example.com/{issuer}
-issuer: x-nmos/auth/v1.0
+baseUri: https://api.example.com/{version}
+version: x-nmos/auth/v1.0
 mediaType: application/json
 documentation:
   - title: Overview

--- a/APIs/AuthorizationAPI.raml
+++ b/APIs/AuthorizationAPI.raml
@@ -4,8 +4,10 @@
 # (c) AMWA 2020
 
 title: NMOS Authorization
-baseUri: https://api.example.com/{version}
-version: x-nmos/auth/v1.0
+baseUri: https://api.example.com/{issuer_id_path}
+baseUriParameters:
+  issuer_id_path:
+    description: The OPTIONAL path component of the issuer ID, in accordance with Section 3 of RFC 8414.
 mediaType: application/json
 documentation:
   - title: Overview

--- a/APIs/ServerMetadataAPI.raml
+++ b/APIs/ServerMetadataAPI.raml
@@ -22,8 +22,8 @@ documentation:
           type: !include schemas/auth_metadata.json
           example: !include ../examples/auth-metadata-get-200.json
 
-  /{issuer_id}:
-    displayName: Authorization Server Metadata with issuer identifier
+  /{issuer_id_path}:
+    displayName: Authorization Server Metadata with issuer identifier path
     get:
       description: Identifies the location of OAuth 2.0 API endpoints as defined in RFC 8414.
       responses:

--- a/APIs/schemas/jwks_response.json
+++ b/APIs/schemas/jwks_response.json
@@ -23,7 +23,8 @@
             "type": "string"
           },
           "kid": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^(x-nmos-[0-9]+)$"
           },
           "x5u": {
             "type": "string",

--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "JSON Web Token Contents",
   "description": "Claims contained within JSON Web Token",
   "type": "object",
@@ -14,15 +14,15 @@
       "type": "string"
     },
     "aud": {
-      "description": "The fully resolved domain name of the intended recipient, or a domain name containing wild-card characters",
+      "description": "The fully qualified domain name of the intended recipient (Resource Server), or a domain name containing wild-card characters",
       "type": "string"
     },
     "exp": {
-      "description": "The UTC epoch time at which the token expires",
+      "description": "The UTC time at which the token expires",
       "type": "number"
     },
     "iat": {
-      "description": "The UTC epoch time at which the token was issued",
+      "description": "The UTC time at which the token was issued",
       "type": "number"
     },
     "client_id": {
@@ -37,18 +37,17 @@
       "description": "An object containing the access permissions of the user for the listed NMOS APIs",
       "type": "object",
       "patternProperties": {
-      	"[a-zA-Z]": {
+        "[a-z_-]": {
           "type": "object",
           "minProperties": 1,
           "patternProperties": {
-          	"^read$|^write$": {
-          	  "type": "array",
+            "^read$|^write$": {
+              "type": "array",
               "items": {
                 "type": "string"
               },
               "minItems": 1
-
-          	}
+            }
           }
         }
       }

--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -39,12 +39,15 @@
       "patternProperties": {
       	"[a-zA-Z]": {
           "type": "object",
+          "minProperties": 1,
           "patternProperties": {
           	"^read$|^write$": {
           	  "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "minItems": 1
+
           	}
           }
         }

--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON Web Token Contents",
+  "description": "Claims contained within JSON Web Token",
+  "type": "object",
+  "properties": {
+    "iss": {
+      "description": "The DNS name of the Authorization Server issuing the token",
+      "type": "string",
+      "format": "uri"
+    },
+    "sub": {
+      "description": "The unique identifier assigned to the end-user by the user authorization system",
+      "type": "string"
+    },
+    "aud": {
+      "description": "The fully resolved domain name of the intended recipient, or a domain name containing wild-card characters",
+      "type": "string"
+    },
+    "exp": {
+      "description": "The UTC epoch time at which the token expires",
+      "type": "number"
+    },
+    "iat": {
+      "description": "The UTC epoch time at which the token was issued",
+      "type": "number"
+    },
+    "client_id": {
+      "description": "The client identifier of the OAuth 2.0 client that requested the token",
+      "type": "string"
+    },
+    "scope": {
+      "description": "A string containing a space-separated list of scopes associated with the token",
+      "type": "string"
+    },
+    "x-nmos-api": {
+      "description": "An object containing the access permissions of the user for the listed NMOS APIs",
+      "type": "object",
+      "patternProperties": {
+      	"[a-zA-Z]": {
+          "type": "object",
+          "patternProperties": {
+          	"^read$|^write$": {
+          	  "type": "array",
+              "items": {
+                "type": "string"
+              }
+          	}
+          }
+        }
+      }
+    }
+  },
+  "required": ["iss", "sub", "aud", "exp", "client_id", "x-nmos-api"]
+}

--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -15,7 +15,10 @@
     },
     "aud": {
       "description": "The fully qualified domain name of the intended recipient (Resource Server), or a domain name containing wild-card characters",
-      "type": "string"
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "exp": {
       "description": "The UTC time at which the token expires",

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -28,7 +28,7 @@ is not concerned with the security of the connection used to carry out authoriza
 interactions, for the authorization mechanisms described in this document to be effective the connection used MUST
 be encrypted.
 
-Implementation of [BCP-003-01][BCP-003-01] is a RECOMMENDED prerequisite to implementing this document.
+Implementation of [BCP-003-01] is a RECOMMENDED prerequisite to implementing this document.
 
 ## OAuth RFCs
 
@@ -136,12 +136,13 @@ authorization request whist the input-restricted device polls the authorization 
 ### Deprecated Grants (Informative)
 
 The implicit grant, password credentials grant, and client credentials grant have now been deprecated in use by the
-IETF's [Best Common Practices][oauth-bcp-13], being replaced with the authorization code grant flow using PKCE.
+IETF's [Best Common Practices][oauth-security-topics], being replaced with the authorization code grant flow using
+PKCE.
 
 The implicit grant was originally designed for use with public clients and Single Page Web Applications who could not
 feasibly keep their client credentials safe. This redirection grant issued the access token in the redirection URI and
 was susceptable to access token leakage and access token replay attacks described in the IETF's
-[Best Common Practices][oauth-bcp-13].
+[Best Common Practices][oauth-security-topics].
 
 The resource owner password credentials grant was designed for situations where the resource owner had a strong trust
 relationship with the client - this was typically reserved for first-party software applications. This grant has been
@@ -150,6 +151,18 @@ deprecated, due to the anti-pattern of submitting user credentials to the client
 The client credentials grant was designed for confidential clients, but requires the resource owner arrange for the
 Authorization Server to allow access to protected resources out of band of the authorization process. This grant is
 usually used in machine-to-machine operations in which there is no concept of a user.
+
+## Future Considerations
+
+- The Device Authorization Grant ([RFC-8628]) may be added to this specification to enable resource-constrained
+  devices to make use of a second device to enable user authorization.
+- The Client Credentials Grant may be permitted for machine-to-machine interactions within the NMOS [IS-06] endpoint
+  registration process.
+- Use of the [Resource Indicators][oauth-resource-indicators] request parameters may be added to enable a client to
+  explicitly signal to an
+  authorization server about the specific protected resource(s) to which it is requesting access
+- Use of [Mutual-TLS and Certificate Bound Tokens][oauth-mtls] may be added to provide a means of client
+  authentication to the Authorization Server via mutual TLS and the binding of access tokens to client certificates.
 
 
 [RFC-2119]: https://tools.ietf.org/html/rfc2119 "Key words for use in RFCs"
@@ -178,6 +191,12 @@ usually used in machine-to-machine operations in which there is no concept of a 
 
 [RFC-8628]: https://tools.ietf.org/html/rfc8628 "OAuth 2.0 Device Authorization Grant"
 
+[oauth-security-topics]: https://datatracker.ietf.org/doc/draft-ietf-oauth-security-topics/ "OAuth 2.0 Security Best Current Practice"
+
+[oauth-resource-indicators]: https://datatracker.ietf.org/doc/draft-ietf-oauth-resource-indicators/ "Resource Indicators for OAuth 2.0"
+
+[oauth-mtls]: https://datatracker.ietf.org/doc/draft-ietf-oauth-mtls/ "OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens"
+
 [BCP-003-01]: https://github.com/AMWA-TV/nmos-api-security/blob/v1.0-dev/best-practice-secure-comms.md
 
-[oauth-bcp-13]: https://tools.ietf.org/html/draft-ietf-oauth-security-topics-13 "OAuth 2.0 Security Best Current Practice 13"
+[IS-06]: https://amwa-tv.github.io/nmos-network-control/ "AMWA IS-06 NMOS Network Control Specification"

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -97,7 +97,7 @@ response (Found) as stated in Section 4.1.2 of [RFC 6749][RFC-6749] following th
 [RFC 7231][RFC-7231].
 
 The Authorization Server MUST NOT use the 307 HTTP status code for redirection as per Section 4.10. of the [OAuth
-2.0 Best Common Practice][oauth-bcp-13] draft.
+2.0 Best Common Practice][oauth-security-topics] draft.
 
 ### OPTIONS Requests
 
@@ -144,6 +144,6 @@ instead implement more generic handling for ranges of response codes (1xx, 2xx, 
 
 [RFC-8414]: https://tools.ietf.org/html/rfc8414 "OAuth 2.0 Authorization Server Metadata"
 
-[oauth-bcp-13]: https://tools.ietf.org/html/draft-ietf-oauth-security-topics-13 "OAuth 2.0 Security Best Current Practice 13"
+[oauth-security-topics]: https://datatracker.ietf.org/doc/draft-ietf-oauth-security-topics/ "OAuth 2.0 Security Best Current Practice 13"
 
 [cross-origin]: https://www.w3.org/TR/cors "Cross-Origin Resource Sharing"

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -34,6 +34,8 @@ The base of the API MAY be found at the following location as-per other NMOS spe
 https://<ip address or hostname>:<port>/x-nmos/auth/<api version>/
 ```
 
+### Server Metadata Endpoint
+
 The Authorization Server MUST implement an endpoint at the following path. This path immediately follows the port and
 MUST NOT be prefixed by any additional path, including but not limited to 'x-nmos'. This endpoint cannot follow the
 usual format of NMOS API's due to it following the syntax and semantics of ".well-known" endpoints defined in
@@ -42,7 +44,9 @@ usual format of NMOS API's due to it following the syntax and semantics of ".wel
 *   **/.well-known/oauth-authorization-server[/issuer]** - This path MUST return a response matching the requirements
 of OAuth 2.0 Authorization Server Metadata [RFC 8414][RFC-8414]. This MUST include the optional `jwks_uri`,
 `registration_endpoint` and `revocation_endpoint` parameters. The issuer identifier path (`/issuer`) is optional and
-defined in the [Discovery](./3.0.%20Discovery.md) Section. .
+defined in the [Discovery](./3.0.%20Discovery.md) Section.
+
+### Endpoints
 
 The following additional paths MUST be implemented by an Authorization Server, but MAY be re-located to alternative
 paths provided they are correctly signalled in the Authorization Server Metadata.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -41,10 +41,10 @@ MUST NOT be prefixed by any additional path, including but not limited to 'x-nmo
 usual format of NMOS API's due to it following the syntax and semantics of ".well-known" endpoints defined in
 [RFC 5785][RFC-5785].
 
-*   **/.well-known/oauth-authorization-server[/issuer]** - This path MUST return a response matching the requirements
-of OAuth 2.0 Authorization Server Metadata [RFC 8414][RFC-8414]. This MUST include the optional `jwks_uri`,
-`registration_endpoint` and `revocation_endpoint` parameters. The issuer identifier path (`/issuer`) is optional and
-defined in the [Discovery](./3.0.%20Discovery.md) Section.
+*   **/.well-known/oauth-authorization-server[/<issuer_id_path>]** - This path MUST return a response matching the
+requirements of OAuth 2.0 Authorization Server Metadata [RFC 8414][RFC-8414]. This MUST include the optional
+`jwks_uri`, `registration_endpoint` and `revocation_endpoint` parameters. The issuer identifier path
+(`/<issuer_id_path>`) is optional and defined in the [Discovery](./3.0.%20Discovery.md) Section.
 
 ### Endpoints
 

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -35,10 +35,10 @@ authorization-server" MUST be used to identify the Authorization Server metadata
 Authorization Server metadata URL should take the form:
 
 ```
-<api_proto>://<hostname>:<port>/.well-known/oauth-authorization-server[/<api_label>]
+<api_proto>://<hostname>:<port>/.well-known/oauth-authorization-server[/<api_selector>]
 ```
 
-Where `./well-known/oauth-authorization-server` forms the "well-known URI suffix" and the optional `api_label` forms
+Where `./well-known/oauth-authorization-server` forms the "well-known URI suffix" and the optional `api_selector` forms
 the "issuer identifier path", with the latter enabling support for multiple issuers per host. Placeholders are
 described in [DNS-SD TXT Records](#dns-sd-txt-records) below.
 
@@ -69,7 +69,7 @@ The DNS-SD advertisement MUST be accompanied by a TXT record of name `api_ver`. 
 comma-separated list of API versions supported by the server. For example: `v1.0,v1.1,v2.0`. There should be no
 whitespace between commas, and versions should be listed in ascending order.
 
-This TXT record MUST NOT be used to form the URL of the authorization server endpoints, with the `api_label` record
+This TXT record MUST NOT be used to form the URL of the authorization server endpoints, with the `api_selector` record
 used instead to locate the server metadata endpoint. The `api_ver` TXT record should instead be used solely as an
 indicator to the client of what versions of this specification the authorization service supports.
 
@@ -81,14 +81,14 @@ TXT record should be used in favour of the SRV priority and weight where these v
 issues in the Bonjour and Avahi implementations. Values 0 to 99 correspond to an active NMOS Authorization Server API
 (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.
 
-#### api_label
+#### api_selector
 
-The DNS_SD advertisement MAY include a TXT record of name `api_label`. The value of this TXT record is a string
+The DNS_SD advertisement MAY include a TXT record of name `api_selector`. The value of this TXT record is a string
 relating to the "issuer identifier", as described in Section 3.1 of [RFC 8414][RFC-8414], and is appended to the
 server metadata URL. If this record is omitted or is equal to an empty string, the value of this record MUST be
 omitted from the path specifier for the `well-known` endpoint.
 
-The `api_label` TXT record value MAY be equal to the NMOS API version supported by the advertised host.
+The `api_selector` TXT record value MAY be equal to the NMOS API version supported by the advertised host.
 
 ## Implementation Notes
 

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -35,7 +35,7 @@ authorization-server" MUST be used to identify the Authorization Server metadata
 Authorization Server metadata URL should take the form:
 
 ```
-{ api_proto }://{ hostname }:{ port }/.well-known/oauth-authorization-server[/{ api_label }]
+<api_proto>://<hostname>:<port>/.well-known/oauth-authorization-server[/<api_label>]
 ```
 
 Where `./well-known/oauth-authorization-server` forms the "well-known URI suffix" and the optional `api_label` forms

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -88,7 +88,8 @@ relating to the "issuer identifier path", as described in Section 3.1 of [RFC 84
 server metadata URL. If this record is omitted or is equal to an empty string, the value of this record MUST be
 omitted from the path specifier for the `well-known` endpoint.
 
-The `api_selector` TXT record value MAY be equal to the NMOS API version supported by the advertised host.
+The `api_selector` TXT record value MAY be equal to the NMOS API path prefix used by the advertised host (for example
+`x-nmos/auth/v1.0`).
 
 ## Implementation Notes
 

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -84,7 +84,7 @@ issues in the Bonjour and Avahi implementations. Values 0 to 99 correspond to an
 #### api_selector
 
 The DNS_SD advertisement MAY include a TXT record of name `api_selector`. The value of this TXT record is a string
-relating to the "issuer identifier", as described in Section 3.1 of [RFC 8414][RFC-8414], and is appended to the
+relating to the "issuer identifier path", as described in Section 3.1 of [RFC 8414][RFC-8414], and is appended to the
 server metadata URL. If this record is omitted or is equal to an empty string, the value of this record MUST be
 omitted from the path specifier for the `well-known` endpoint.
 

--- a/docs/4.1. Behaviour - Clients.md
+++ b/docs/4.1. Behaviour - Clients.md
@@ -44,7 +44,8 @@ This endpoint MUST be exactly identical to one of the entries in the array of re
 registration.
 
 Redirect URIs MUST be complete (fully-qualified) and not use pattern-matching, as this makes them susceptible to
-Redirect URI Validation Attacks, described in Section 4.1. in [oauth-bcp-13].
+Redirect URI Validation Attacks, described in Section 4.1. in the
+[OAuth 2.0 Security Best Current Practice][oauth-security-topics] document.
 
 All registered redirect URI's for Clients SHOULD mandate use of TLS or other transport-layer security
 method.
@@ -75,12 +76,12 @@ according to Section 2.1 of [RFC 6749][RFC-6749]. Browser applications that have
 keeping client credentials secure and therefore can be treated as a confidential client.
 
 Browser-based applications SHOULD abide by the guidelines set out in
-[OAuth 2.0 for Browser-Based Apps][draft-ietf-oauth-browser-based-apps-04].
+[OAuth 2.0 for Browser-Based Apps][oauth-browser-based-apps].
 
 Browser-based applications communicating with an Authorization Server and Resource Server on the same domain are
 RECOMMENDED to take advantage of using domain-specific, HTTP-Only cookies to store and exchange access tokens with
 Resource Servers, due to their resilience to Cross-Site Scripting attacks, as stated in Section 6.1 of
-[OAuth 2.0 for Browser-Based Apps][draft-ietf-oauth-browser-based-apps-04].
+[OAuth 2.0 for Browser-Based Apps][oauth-browser-based-apps].
 
 Browser-based applications are NOT RECOMMENDED to store access tokens or refresh tokens in local storage due to their
 susceptibility to Cross-Site-Scripting attacks, and instead rely on in-memory storage during the session.
@@ -127,6 +128,6 @@ Clients MUST be capable of handling early revocation of tokens, which will be si
 
 [RFC-8414]: https://tools.ietf.org/html/rfc8414 "OAuth 2.0 Authorization Server Metadata"
 
-[draft-ietf-oauth-browser-based-apps-04]: https://tools.ietf.org/html/draft-ietf-oauth-browser-based-apps-04 "OAuth 2.0 for Browser-Based Apps"
+[oauth-browser-based-apps]: https://datatracker.ietf.org/doc/draft-ietf-oauth-browser-based-apps/ "OAuth 2.0 for Browser-Based Apps"
 
-[oauth-bcp-13]: https://tools.ietf.org/html/draft-ietf-oauth-security-topics-13 "OAuth 2.0 Security Best Current Practice 13"
+[oauth-security-topics]: https://datatracker.ietf.org/doc/draft-ietf-oauth-security-topics/ "OAuth 2.0 Security Best Current Practice 13"

--- a/docs/4.2. Behaviour - Token Requests.md
+++ b/docs/4.2. Behaviour - Token Requests.md
@@ -56,10 +56,11 @@ Section 5.1. Additionally the `expires_in` and `refresh_token` fields MUST be in
 
 ## Refresh Tokens
 
-A refresh token is a string representing the authorization granted to the client by the resource owner. Refresh
-tokens are issued to the client by the authorization server and are used to obtain a new access token when the current
-access token becomes invalid or expires, in accordance with Section 1.5 of [RFC 6749][RFC-6749]. The process of
-refreshing an access token is outlined in Section 6 of [RFC 6749][RFC-6749].
+A refresh token is a string representing the authorization granted to the client by the resource owner. Refresh tokens
+are issued to the client by the authorization server and are used to obtain a new access token when the current access
+token becomes invalid or expires, in accordance with Section 1.5 of [RFC 6749][RFC-6749]. A refresh token MUST be at
+least 40 characters in length. The process of refreshing an access token is outlined in Section 6 of
+[RFC 6749][RFC-6749].
 
 Authorization Servers MUST issue refresh tokens in the Bearer token returned after the completion of an authentication
 flow. Each refresh token SHOULD be time-limited.
@@ -80,9 +81,8 @@ _Found at the `/revoke` endpoint in the example implementation_
 Access Tokens and Refresh Tokens SHALL be revoked by the Authorization Server as defined by [RFC 7009][RFC-7009].
 
 OAuth 2.0 clients SHALL revoke any valid refresh tokens using the revocation endpoint upon a user ceasing to require
-authorization. This may be, for example, due to logging out of an application, a change of user identity or uninstalling
-a given application.
-
+authorization. This may be, for example, due to logging out of an application, a change of user identity or
+uninstalling a given application.
 
 [RFC-6749]: https://tools.ietf.org/html/rfc6749 "The OAuth 2.0 Authorization Framework"
 

--- a/docs/4.2. Behaviour - Token Requests.md
+++ b/docs/4.2. Behaviour - Token Requests.md
@@ -4,19 +4,19 @@ _(c) AMWA 2019, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
 ## Grants
 
-The implicit grant MUST NOT be used as it has been deprecated in Section 3.1.2. of the [OAuth 2.0 Best Common
-Practice][oauth-bcp-13] guidelines.
+The implicit grant MUST NOT be used as it has been deprecated in Section 3.1.2. of the
+[OAuth 2.0 Best Common Practice][oauth-security-topics] guidelines.
 
-The password grant SHOULD NOT be used as it has been deprecated in Section 3.4. of the [OAuth 2.0 Best Common
-Practice][oauth-bcp-13] guidelines.
+The password grant SHOULD NOT be used as it has been deprecated in Section 3.4. of the
+[OAuth 2.0 Best Common Practice][oauth-security-topics] guidelines.
 
 The client credentials grant MUST NOT be used as it provides the lowest form of protection and is reserved for
 applications accessing their own resources.
 
 The Authorization Code Grant MUST be supported by the Authorization Server, and SHOULD act as the primary grant flow.
 When used with Public Clients, this grant MUST be used alongside PKCE as outlined in [RFC 7636][RFC-7636], in-keeping
-with the recommendations given in 3.1.1. of the [OAuth 2.0 Best Common Practice][oauth-bcp-13]. When using PKCE,
-clients MUST support and prefer the "S256" `code_challenge_method`.
+with the recommendations given in 3.1.1. of the [OAuth 2.0 Best Common Practice][oauth-security-topics]. When using
+PKCE, clients MUST support and prefer the "S256" `code_challenge_method`.
 
 The Refresh Token Grant MUST be supported in order to ease the refreshing of access tokens and reduce the number user
 authorization requests.
@@ -73,7 +73,7 @@ to re-authenticate, provided the refresh token is not explicitly revoked or has 
 
 In the case of Browser-Based Clients, when issuing a rotated refresh token, the Refresh Token MUST be time-limited and
 the Authorization Server MUST NOT extend the lifetime of the new refresh token beyond the lifetime of the initial
-refresh token, as stated in Section 8 of [OAuth 2.0 for Browser-Based Apps].
+refresh token, as stated in Section 8 of [OAuth 2.0 for Browser-Based Apps][oauth-browser-based-apps].
 
 ## Token Revocation
 _Found at the `/revoke` endpoint in the example implementation_
@@ -94,6 +94,6 @@ uninstalling a given application.
 
 [RFC-8628]: https://tools.ietf.org/html/rfc8628 "OAuth 2.0 Device Authorization Grant"
 
-[oauth-bcp-13]: https://tools.ietf.org/html/draft-ietf-oauth-security-topics-13 "OAuth 2.0 Security Best Current Practice 13"
+[oauth-security-topics]: https://datatracker.ietf.org/doc/draft-ietf-oauth-security-topics/ "OAuth 2.0 Security Best Current Practice 13"
 
-[OAuth 2.0 for Browser-Based Apps]: https://datatracker.ietf.org/doc/draft-ietf-oauth-browser-based-apps
+[oauth-browser-based-apps]: https://datatracker.ietf.org/doc/draft-ietf-oauth-browser-based-apps

--- a/docs/4.3. Behaviour - Access Tokens.md
+++ b/docs/4.3. Behaviour - Access Tokens.md
@@ -72,17 +72,18 @@ SHALL issue a token with an `iat` claim that is equal to the UTC time at which t
 ### client_id
 _Client ID that requested the token_
 
-The `client_id` claim MUST be included in the token, as per Section 2.2 of the draft RFC [Profile for OAuth 2.0 Access
-Tokens]. This claim corresponds with the client identifier of the OAuth 2.0 client that requested the token. The value
-of this claim MUST exactly match the full client identifier to which the token was granted.
+The `client_id` claim MUST be included in the token, as per Section 2.2 of the draft RFC
+[Profile for OAuth 2.0 Access Tokens][oauth-access-token-jwt]. This claim corresponds with the client identifier of the
+OAuth 2.0 client that requested the token. The value of this claim MUST exactly match the full client identifier to
+which the token was granted.
 
 ### scope
 _List of scopes associated with the token_
 
 The `scope` claim SHOULD be included in the token, if the authorization request included a scope parameter, as per
-Section 2.2.2 of the draft RFC [Profile for OAuth 2.0 Access Tokens]. The value of the "scope" claim is a JSON string
-containing a space-separated list of scopes associated with the token, in the format described in Section 3.3 of
-[RFC6749][RFC-6749].
+Section 2.2.2 of the draft RFC [Profile for OAuth 2.0 Access Tokens][oauth-access-token-jwt]. The value of the "scope"
+claim is a JSON string containing a space-separated list of scopes associated with the token, in the format described
+in Section 3.3 of [RFC6749][RFC-6749].
 
 ## Private Claims
 
@@ -223,7 +224,7 @@ invalid during transit. As such it is RECOMMENDED that tokens be valid for at le
 
 [RFC-7519]: https://tools.ietf.org/html/rfc7519 "JSON Web Token (JWT)"
 
-[Profile for OAuth 2.0 Access Tokens]: https://datatracker.ietf.org/doc/draft-ietf-oauth-access-token-jwt/ "JSON Web Token Profile for OAuth 2.0 Access Tokens"
+[oauth-access-token-jwt]: https://datatracker.ietf.org/doc/draft-ietf-oauth-access-token-jwt/ "JSON Web Token Profile for OAuth 2.0 Access Tokens"
 
 [AMWA NMOS Parameter Registers]: https://github.com/AMWA-TV/nmos-parameter-registers
 

--- a/docs/4.3. Behaviour - Access Tokens.md
+++ b/docs/4.3. Behaviour - Access Tokens.md
@@ -95,38 +95,44 @@ _Contains information particular to the NMOS API the token is intended for_
 The `x-nmos-api` claim MUST be included in the token. The value of the claim is a JSON object, the contents of which
 are `key:value` pairs, with the `key` identifying an individual AMWA NMOS API using the namespace identifier found in
 the URL for that given API (e.g. "registration", "query", etc.), and the `value` being a JSON object indicating access
-permissions for that API. An empty `x-nmos-api` claim MUST indicate no access to any of the APIs. A missing API key
+permissions for that API. An empty `x-nmos-api` object MUST indicate no access to any of the APIs. A missing API key
 MUST indicate no access to that specific API.
 
 #### The Access Permissions Object
 The value of each NMOS API key is the access permissions object for the given user for that specific API. The access
-permission object consists of `key:value` pairs in which the `key` denotes a specific access right. General access
-rights include:
+permission object consists of `key:value` pairs in which the `key` denotes a specific permission. General permissions
+include:
 *   **write** - ability to insert a new, or edit an existing, resource. This takes the form of *POST*, *PUT*,
     *PATCH* and *DELETE* HTTP request verbs.
 *   **read** - ability to retrieve the resource. This takes the form of *GET*, *OPTIONS* and *HEAD* HTTP request
     verbs.
 
-If a specific access right is not permitted for a given user, the access right MUST be omitted, to prevent token bloat.
-If all access rights are not permitted for a given API, the API key MUST be removed from the `x-nmos-api` claim, to
-ensure token size is minimised.
+If a permission has not been granted to a specific user, the permission key MUST be omitted, to minimise the
+token size. If no permissions are given for a specific API, the API key MUST be removed from the `x-nmos-api` claim,
+to ensure token size is minimised.
 
-If an access right value of "write" is given in the access permission object, and the intention is that the given user
-also has "read" access to the given API, a value of "read" MUST also be present in the access permissions object.
+If a permission of "write" is given in the access permission object, and the intention is that the given user
+also has "read" access to the specific API, a permission key of "read" MUST also be present in the access permissions
+object.
 
-Individual AMWA specifications MAY specify additional access rights specific to the individual API. These MUST be
-registered in the [AMWA NMOS Parameter Registers].
+Individual AMWA specifications MAY specify additional permissions keys specific to the individual API. These MUST be
+registered in the [AMWA NMOS Parameter Registers]. It is recommended that new permissions keys are only introduced
+alongside a new version of a given AMWA NMOS API in order to minimise the risk of incompatibility.
 
-The `value` corresponding to each access right is a JSON array containing URL path specifiers that the user is
+The `value` corresponding to each permission key is a JSON array containing URL path specifiers that the user is
 permitted to perform the specific request against. Wildcards are permitted in the path specifiers. The means by which
-wildcards may be used for pattern matching SHALL align with Section 2.13 of the [POSIX Standard]. For NMOS API
-URL's that follow the standard pattern of:
+wildcards may be used for pattern matching SHALL align with Section 2.13 of the [POSIX Standard]. It is RECOMMENDED
+that wildcards are used in place of URL parameters (such as specifying resource UUID's) to minimise token size.
+Specific URL parameters MAY be used in path specifiers if defining access to a small number of resources (such as
+a single node or device.)
+
+For NMOS API URL's that follow the standard pattern of:
 
 `<api_proto>://<hostname>:<port>/x-nmos/<api type>/<api version>/`
 
-all path specifiers MUST start _after_ the API version. For example, authorizing a user to read all _single resources_
-and modify the configuration of all  _single senders_ at a Connection Management interface would result in an access
-permissions object of:
+all path specifiers MUST start _after_ the API version and its trailing slash. For example, authorizing a user to read
+all _single resources_ and modify the configuration of all  _single senders_ at a Connection Management interface would
+result in an access permissions object of:
 
 ```JSON
 "connection": {
@@ -143,8 +149,7 @@ with an IS-04 Registry.
 ```json
 "x-nmos-api": {
   "registration": {
-    "read": ["*"],
-    "write": []
+    "read": ["*"]
   },
   "query": {
     "read": ["*"],
@@ -176,10 +181,10 @@ claims, and ensure that enough space is available in the header for both the tok
   "aud": "https://node-*.example.com",
   "iat": 1548779460,
   "exp": 1548783060,
-  "scope": "register query connection",
+  "scope": "registration query connection",
   "client_id": "hopy0dNRPNTiGJDqPfqYwGmw",
   "x-nmos-api": {
-    "register": {
+    "registration": {
       "read": ["*"],
     },
     "query": {

--- a/docs/4.3. Behaviour - Access Tokens.md
+++ b/docs/4.3. Behaviour - Access Tokens.md
@@ -45,9 +45,9 @@ is being requested.
 ### aud
 _Identifies the recipients of the JWT_
 
-The `aud` (audience) claim MUST be included in the token. This claim MUST contain the fully resolved domain name of
-the intended recipient, or a domain name containing wild-card characters in order to target a subset of devices on a
-network. Such wild-carding of domain names is documented in [RFC 4592][RFC-4592].
+The `aud` (audience) claim MUST be included in the token. This claim MUST be a JSON array containing the fully resolved
+domain names of the intended recipients, or a domain name containing wild-card characters in order to target a subset
+of devices on a network. Such wild-carding of domain names is documented in [RFC 4592][RFC-4592].
 
 If the `aud` claim is present and does not match the fully resolved domain name of the resource server, the Resource
 Server MUST reject the token.
@@ -178,7 +178,7 @@ claims, and ensure that enough space is available in the header for both the tok
 {
   "iss": "https://auth.example.com",
   "sub": "username@example.com",
-  "aud": "https://node-*.example.com",
+  "aud": ["https://node-*.example.com"],
   "iat": 1548779460,
   "exp": 1548783060,
   "scope": "registration query connection",

--- a/docs/4.3. Behaviour - Access Tokens.md
+++ b/docs/4.3. Behaviour - Access Tokens.md
@@ -85,6 +85,10 @@ Section 2.2.2 of the draft RFC [Profile for OAuth 2.0 Access Tokens][oauth-acces
 claim is a JSON string containing a space-separated list of scopes associated with the token, in the format described
 in Section 3.3 of [RFC6749][RFC-6749].
 
+The value of each scope corresponds to the namespace identifier for a given NMOS
+API (e.g. "registration", "query", etc.) to which the user is requesting access and determines how the private
+`x-nmos-api` claim, detailed below, is populated.
+
 ## Private Claims
 
 [RFC 7519][RFC-7519] allows for "private claims". The following claim is used to identify the API specification a given

--- a/docs/4.3. Behaviour - Tokens.md
+++ b/docs/4.3. Behaviour - Tokens.md
@@ -181,9 +181,18 @@ claims, and ensure that enough space is available in the header for both the tok
   "scope": ["register", "query", "connection"],
   "client_id": "hopy0dNRPNTiGJDqPfqYwGmw",
   "x-nmos-api": {
-    "register": ["read"],
-    "query": ["read", "write"],
-    "connection": ["write", "read"]
+    "register": {
+      "read": ["*"],
+      "write": []
+    },
+    "query": {
+      "read": ["*"],
+      "write": ["subscriptions.*"]
+    },
+    "connection": {
+      "read": ["*"],
+      "write": ["single.*"]
+    }
   }
 }
 ```

--- a/docs/4.3. Behaviour - Tokens.md
+++ b/docs/4.3. Behaviour - Tokens.md
@@ -96,39 +96,66 @@ _Contains information particular to the NMOS API the token is intended for_
 
 The `x-nmos-api` claim MUST be included in the token. The value of the claim is a JSON object, the contents of which
 are `key:value` pairs, with the `key` identifying an individual AMWA NMOS API using the identifier found in the DNS-SD
-advertisement, and the `value` being a JSON array indicating access permissions for that API. An empty `x-nmos-api`
+advertisement, and the `value` being a JSON object indicating access permissions for that API. An empty `x-nmos-api`
 claim MUST indicate no access to any of the APIs. A missing API key MUST indicate no access to that specific API. An
-empty access array MUST indicate no access to that specific API also.
+empty access permissions object MUST indicate no access to that specific API also.
 
 ```json
 "x-nmos-api": {
-  "register": [],
-  "connection": []
+  "register": {},
+  "connection": {}
 }
 ```
 
-The `value` for each NMOS API indicates the access rights of the given user for that specific API. The value required
-by the Resource Server MUST exactly match one of the values in the array. General access rights include:
+##### The Access Permissions Object
+
+The value of each NMOS API key is the access permissions object for the given user for that specific API. The access
+permission object consists of `key:value` pairs in which the `key` denotes a specific access right. General access
+rights include:
 *   **write** - ability to insert a new, or edit an existing, resource. This takes the form of *POST*, *PUT*,
     *PATCH* and *DELETE* HTTP request verbs.
 *   **read** - ability to retrieve the resource. This takes the form of *GET*, *OPTIONS* and *HEAD* HTTP request
     verbs.
 
-If a value of "write" is given in an access array, and the intention is that the given user also has "read" access to
-a given API, the value of "read" MUST also occur in the array.
+If an access right value of "write" is given in the access permission object, and the intention is that the given user
+also has "read" access to the given API, a value of "read" MUST also be present in the access permissions object.
 
-Individual AMWA specifications MAY specify additional values specific to the individual API. These MUST be registered
-in the [AMWA NMOS Parameter Registers].
+Individual AMWA specifications MAY specify additional access rights specific to the individual API. These MUST be
+registered in the [AMWA NMOS Parameter Registers].
+
+The `value` corresponding to each access right is a JSON array containing path specifiers that the user is permitted
+to perform the specific request against. Wildcards are permitted in the path specifiers. The path specifiers MUST use
+dot notation to signify specific sub-paths of the endpoint. For NMOS API's following the standard pattern, all path
+specifiers MUST start _after_ the API version.
+
+For example, authorizing a user to read all _single resources_ and make connections between all _single senders_ at a
+Connection Management interface would result in an access permissions object of:
+
+```JSON
+"connection": {
+  "read": ["single.*"],
+  "write": ["single.senders.*"]
+}
+```
 
 An example of a `x-nmos-api` claim is shown below. This would permit querying an IS-04 Registry, and making
-connections via an IS-05 connection management interface, but would not permit the user to register a resource with
-an IS-04 Registry.
+_single_ connections via an IS-05 connection management interface, but would not permit the user to register a resource
+with an IS-04 Registry.
 
 ```json
 "x-nmos-api": {
-  "register": ["read"],
-  "query": ["read", "write"],
-  "connection": ["write", "read"]
+  "register": {
+    "read": ["*"],
+    "write": []
+  },
+  "query": {
+    "read": ["*"],
+    "write": ["subscriptions.*"]
+  },
+  "connection": {
+    "read": ["*"],
+    "write": ["single.*"]
+  }
 }
 ```
 

--- a/docs/4.3. Behaviour - Tokens.md
+++ b/docs/4.3. Behaviour - Tokens.md
@@ -95,17 +95,10 @@ token is used for.
 _Contains information particular to the NMOS API the token is intended for_
 
 The `x-nmos-api` claim MUST be included in the token. The value of the claim is a JSON object, the contents of which
-are `key:value` pairs, with the `key` identifying an individual AMWA NMOS API using the identifier found in the DNS-SD
-advertisement, and the `value` being a JSON object indicating access permissions for that API. An empty `x-nmos-api`
-claim MUST indicate no access to any of the APIs. A missing API key MUST indicate no access to that specific API. An
-empty access permissions object MUST indicate no access to that specific API also.
-
-```json
-"x-nmos-api": {
-  "register": {},
-  "connection": {}
-}
-```
+are `key:value` pairs, with the `key` identifying an individual AMWA NMOS API using the namespace identifier found in
+the URL for that given API (e.g. "registration", "query", etc.), and the `value` being a JSON object indicating access
+permissions for that API. An empty `x-nmos-api` claim MUST indicate no access to any of the APIs. A missing API key
+MUST indicate no access to that specific API.
 
 ##### The Access Permissions Object
 
@@ -117,44 +110,47 @@ rights include:
 *   **read** - ability to retrieve the resource. This takes the form of *GET*, *OPTIONS* and *HEAD* HTTP request
     verbs.
 
+If a specific access right is not permitted for a given user, the access right MUST be omitted, to prevent token bloat.
+If all access rights are not permitted for a given API, the API key MUST be removed from the `x-nmos-api` claim, to
+ensure token size is minimised.
+
 If an access right value of "write" is given in the access permission object, and the intention is that the given user
 also has "read" access to the given API, a value of "read" MUST also be present in the access permissions object.
 
 Individual AMWA specifications MAY specify additional access rights specific to the individual API. These MUST be
 registered in the [AMWA NMOS Parameter Registers].
 
-The `value` corresponding to each access right is a JSON array containing path specifiers that the user is permitted
-to perform the specific request against. Wildcards are permitted in the path specifiers. The path specifiers MUST use
-dot notation to signify specific sub-paths of the endpoint. For NMOS API's following the standard pattern, all path
-specifiers MUST start _after_ the API version.
+The `value` corresponding to each access right is a JSON array containing URL path specifiers that the user is
+permitted to perform the specific request against. Wildcards are permitted in the path specifiers. For NMOS API's
+following the standard pattern, all path specifiers MUST start _after_ the API version.
 
-For example, authorizing a user to read all _single resources_ and make connections between all _single senders_ at a
-Connection Management interface would result in an access permissions object of:
+For example, authorizing a user to read all _single resources_ and modify the configuration of all _single senders_ at
+a Connection Management interface would result in an access permissions object of:
 
 ```JSON
 "connection": {
-  "read": ["single.*"],
-  "write": ["single.senders.*"]
+  "read": ["single/*"],
+  "write": ["single/senders/*"]
 }
 ```
 
-An example of a `x-nmos-api` claim is shown below. This would permit querying an IS-04 Registry, and making
+An example of a `x-nmos-api` claim is shown below. This would permit querying an IS-04 Registry, and modifying
 _single_ connections via an IS-05 connection management interface, but would not permit the user to register a resource
 with an IS-04 Registry.
 
 ```json
 "x-nmos-api": {
-  "register": {
+  "registration": {
     "read": ["*"],
     "write": []
   },
   "query": {
     "read": ["*"],
-    "write": ["subscriptions.*"]
+    "write": ["subscriptions/*"]
   },
   "connection": {
     "read": ["*"],
-    "write": ["single.*"]
+    "write": ["single/*"]
   }
 }
 ```
@@ -183,15 +179,14 @@ claims, and ensure that enough space is available in the header for both the tok
   "x-nmos-api": {
     "register": {
       "read": ["*"],
-      "write": []
     },
     "query": {
       "read": ["*"],
-      "write": ["subscriptions.*"]
+      "write": ["subscriptions/*"]
     },
     "connection": {
       "read": ["*"],
-      "write": ["single.*"]
+      "write": ["single/*"]
     }
   }
 }

--- a/docs/4.3. Behaviour - Tokens.md
+++ b/docs/4.3. Behaviour - Tokens.md
@@ -176,9 +176,9 @@ claims, and ensure that enough space is available in the header for both the tok
   "iss": "https://auth.example.com",
   "sub": "username@example.com",
   "aud": "https://node-*.example.com",
-  "iat": "1548779460",
-  "exp": "1548783060",
-  "scope": ["register", "query", "connection"],
+  "iat": 1548779460,
+  "exp": 1548783060,
+  "scope": "register query connection",
   "client_id": "hopy0dNRPNTiGJDqPfqYwGmw",
   "x-nmos-api": {
     "register": {

--- a/docs/4.3. Behaviour - Tokens.md
+++ b/docs/4.3. Behaviour - Tokens.md
@@ -1,8 +1,6 @@
-# Behaviour: Tokens
+# Behaviour: Access Tokens
 
 _(c) AMWA 2019, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
-
-## Access Tokens
 
 The access token type returned MUST be of the `Bearer_token` type specified in [RFC 6750][RFC-6750].
 
@@ -20,13 +18,13 @@ The JWS MUST be signed with `RSASSA-PKCS1-v1_5 using SHA-512`, meaning the value
 }
 ```
 
-### Registered Claims
+## Registered Claims
 
 Registered claims are defined in the authorization JSON Web Token specification in [RFC 7519][RFC-7519], but their
 specific usage is left to the application. NMOS API Clients and Servers implementing this specification MUST employ the
 restrictions on claims outlined below, in addition to implementing tokens as specified in [RFC 7519][RFC-7519].
 
-#### iss
+### iss
 _Identifies principal that issued the JWT_
 
 The `iss` (issuer) claim MUST be included in the token. The claim MUST contain the DNS name and port of the
@@ -34,7 +32,7 @@ Authorization Server accessible to the audience of the token. The contents of th
 common name field or alternate names fields in all TLS certificates used by the Authorization Server for securing the
 authorization API, in order to allow the verifier of the token to fetch the public key of the Authorization Server.
 
-#### sub
+### sub
 _Identifies the subject of the JWT_
 
 The `sub` (subject) claim MUST be included in the token. This claim MUST contain a unique identifier assigned to the
@@ -44,7 +42,7 @@ email address of the user.
 For the authorization code grant, the subject typically identifies the authorized accessor for which the access token
 is being requested.
 
-#### aud
+### aud
 _Identifies the recipients of the JWT_
 
 The `aud` (audience) claim MUST be included in the token. This claim MUST contain the fully resolved domain name of
@@ -54,7 +52,7 @@ network. Such wild-carding of domain names is documented in [RFC 4592][RFC-4592]
 If the `aud` claim is present and does not match the fully resolved domain name of the resource server, the Resource
 Server MUST reject the token.
 
-#### exp
+### exp
 _Expiration time of the token_
 
 The `exp` (expiration) claim MUST be included in the token. This is defined in [RFC 7519][RFC-7519] as being a JSON
@@ -64,21 +62,21 @@ so implementers should take care to ensure they are using the correct epoch.
 API implementations MUST reject a token where the `exp` claim value is less than the current UTC time. Refer to the
 [Token Lifetime](#token-lifetime) Section for guidance on setting this value.
 
-#### iat
+### iat
 _Token issued at time_
 
 The `iat` (issued at) claim MAY be included in the token. As with the `exp` claim this claim uses UTC. API
 implementations MUST reject a token where the `iat` claim is greater than the current UTC time. Authorization Servers
 SHALL issue a token with an `iat` claim that is equal to the UTC time at which the token is issued.
 
-#### client_id
+### client_id
 _Client ID that requested the token_
 
 The `client_id` claim MUST be included in the token, as per Section 2.2 of the draft RFC [Profile for OAuth 2.0 Access
 Tokens]. This claim corresponds with the client identifier of the OAuth 2.0 client that requested the token. The value
 of this claim MUST exactly match the full client identifier to which the token was granted.
 
-#### scope
+### scope
 _List of scopes associated with the token_
 
 The `scope` claim SHOULD be included in the token, if the authorization request included a scope parameter, as per
@@ -86,12 +84,12 @@ Section 2.2.2 of the draft RFC [Profile for OAuth 2.0 Access Tokens]. The value 
 containing a space-separated list of scopes associated with the token, in the format described in Section 3.3 of
 [RFC6749][RFC-6749].
 
-### Private Claims
+## Private Claims
 
 [RFC 7519][RFC-7519] allows for "private claims". The following claim is used to identify the API specification a given
 token is used for.
 
-#### x-nmos-api
+### x-nmos-api
 _Contains information particular to the NMOS API the token is intended for_
 
 The `x-nmos-api` claim MUST be included in the token. The value of the claim is a JSON object, the contents of which
@@ -100,8 +98,7 @@ the URL for that given API (e.g. "registration", "query", etc.), and the `value`
 permissions for that API. An empty `x-nmos-api` claim MUST indicate no access to any of the APIs. A missing API key
 MUST indicate no access to that specific API.
 
-##### The Access Permissions Object
-
+#### The Access Permissions Object
 The value of each NMOS API key is the access permissions object for the given user for that specific API. The access
 permission object consists of `key:value` pairs in which the `key` denotes a specific access right. General access
 rights include:
@@ -121,11 +118,15 @@ Individual AMWA specifications MAY specify additional access rights specific to 
 registered in the [AMWA NMOS Parameter Registers].
 
 The `value` corresponding to each access right is a JSON array containing URL path specifiers that the user is
-permitted to perform the specific request against. Wildcards are permitted in the path specifiers. For NMOS API's
-following the standard pattern, all path specifiers MUST start _after_ the API version.
+permitted to perform the specific request against. Wildcards are permitted in the path specifiers. The means by which
+wildcards may be used for pattern matching SHALL align with Section 2.13 of the [POSIX Standard]. For NMOS API
+URL's that follow the standard pattern of:
 
-For example, authorizing a user to read all _single resources_ and modify the configuration of all _single senders_ at
-a Connection Management interface would result in an access permissions object of:
+`<api_proto>://<hostname>:<port>/x-nmos/<api type>/<api version>/`
+
+all path specifiers MUST start _after_ the API version. For example, authorizing a user to read all _single resources_
+and modify the configuration of all  _single senders_ at a Connection Management interface would result in an access
+permissions object of:
 
 ```JSON
 "connection": {
@@ -134,6 +135,7 @@ a Connection Management interface would result in an access permissions object o
 }
 ```
 
+#### Example `x-nmos-api` Claim
 An example of a `x-nmos-api` claim is shown below. This would permit querying an IS-04 Registry, and modifying
 _single_ connections via an IS-05 connection management interface, but would not permit the user to register a resource
 with an IS-04 Registry.
@@ -158,14 +160,14 @@ with an IS-04 Registry.
 Authorization Servers MAY only have support for certain NMOS API specifications, and MAY only support certain versions
 of such APIs.
 
-### Size Considerations
+## Size Considerations
 
 While [RFC 7519][RFC-7519] does not prescribe a maximum size for an OAuth 2.0 JSON Web Token, it should be noted that
 these tokens are typically used within an HTTP header. While HTTP does not define a header size limit, 8KByte is a
 common limitation in HTTP server implementations. Specification writers should be mindful of this when designing API
 claims, and ensure that enough space is available in the header for both the token and all other HTTP headers.
 
-### Example Access Token Claim Set
+## Example Access Token Claim Set
 
 ```json
 {
@@ -192,16 +194,16 @@ claims, and ensure that enough space is available in the header for both the tok
 }
 ```
 
-### Token Lifetime
+## Access Token Lifetime
 
 A given access token for an NMOS API may be used on more than one Node or Registry instance. If one of these Nodes or
 Registries is compromised, it is possible for that entity to re-use it itself maliciously. While
 the precise duration of token validity should be left to implementers and administrators based on the risk profile,
 these tokens SHOULD be valid for no more than one hour.
 
-However, if tokens are too short-lived, the number of refresh requests to the Authorization Server for new tokens
-starts to become a significant overhead, and any latency involved in using a token may cause it to become invalid
-during transit. As such it is RECOMMENDED that tokens be valid for at least 30 seconds.
+However, if access tokens are too short-lived, the number of refresh requests to the Authorization Server for new
+tokens starts to become a significant overhead, and any latency involved in using a token may cause it to become
+invalid during transit. As such it is RECOMMENDED that tokens be valid for at least 30 seconds.
 
 
 [RFC-4592]: https://tools.ietf.org/html/rfc4592 "The Role of Wildcards in the Domain Name System"
@@ -219,3 +221,5 @@ during transit. As such it is RECOMMENDED that tokens be valid for at least 30 s
 [Profile for OAuth 2.0 Access Tokens]: https://datatracker.ietf.org/doc/draft-ietf-oauth-access-token-jwt/ "JSON Web Token Profile for OAuth 2.0 Access Tokens"
 
 [AMWA NMOS Parameter Registers]: https://github.com/AMWA-TV/nmos-parameter-registers
+
+[POSIX Standard]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html "Shell Command Language"

--- a/docs/4.4. Behaviour - Resource Servers.md
+++ b/docs/4.4. Behaviour - Resource Servers.md
@@ -61,12 +61,12 @@ The certificate containing the public key for verification is found at the publi
 Server that issued the token. This server is identified using the issuer (`iss`) claim within the token.
 
 The value of the claims within the payload of the JWT must also be validated, in line with the
-[Tokens](./4.3.%20Behaviour%20-%20Tokens.md) page in this directory. The request MUST be rejected if:
+[Tokens](./4.3.%20Behaviour%20-%20Access%20Tokens.md) page in this directory. The request MUST be rejected if:
 *   the `iat` claim is greater than the current UTC time.
 *   the `exp` claim is less than the current UTC time.
 *   the Resource Server does not identify itself with the `aud` claim
 *   the request is not permitted by the value of the `x-nmos-api` claim, in line with the method outlined in
-[Tokens](.4.3.%20Behaviour%20-%20Tokens.md).
+[Tokens](./4.3.%20Behaviour%20-%20Access%20Tokens.md).
 
 ## Audit Requirements
 

--- a/docs/4.4. Behaviour - Resource Servers.md
+++ b/docs/4.4. Behaviour - Resource Servers.md
@@ -68,6 +68,10 @@ The value of the claims within the payload of the JWT must also be validated, in
 *   the request is not permitted by the value of the `x-nmos-api` claim, in line with the method outlined in
 [Tokens](./4.3.%20Behaviour%20-%20Access%20Tokens.md).
 
+## Interaction with other NMOS APIs
+
+Any further token validation requirements based on the specific NMOS API being accessed is highlighted in [BCP-03-02].
+
 ## Audit Requirements
 
 Resource Servers MUST maintain a log of each request which they authorize or reject. Logs MUST be stored alongside an
@@ -80,3 +84,5 @@ such as secrets. Logs SHOULD be stored securely and maintained for at least one 
 [RFC-6750]: https://tools.ietf.org/html/rfc6750 "The OAuth 2.0 Authorization Framework: Bearer Token Usage"
 
 [RFC-7515]: https://tools.ietf.org/html/rfc7515 "JSON Web Signature (JWS)"
+
+[BCP-03-02]: https://github.com/AMWA-TV/nmos-api-security/blob/v1.0-dev/best-practice-authorization.md "Best Practice Authorization"


### PR DESCRIPTION
I've altered the wording in the IS-10 Spec so that we have "read" and "write" as the keys in our x-nmos private claim, and added path specifiers with wild-carding. There is a lack of RFC's / specs on globbing and the use of wildcards - not sure if anyone can help out in that respect.

I've also added a JSON schema for what we expect the token contents to look like. This isn't called out in the RAML (due to the access tokens being base64-url encoded and signed) but passing it through an online JSON schema validator seems to think its a valid schema (however none seem to validate the `pattern Properties" fields correctly.)