### PR TITLE
Resolve many linting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# [Work In Progress] AMWA IS-10 NMOS Authorization Specification
+# \[Work In Progress\] AMWA IS-10 NMOS Authorization Specification
 
 AMWA IS-10 specifies an API for the authorization of other NMOS APIs. 
 
 This repository provides the "source" for this Specification.
 
-For an HTML rendering of this Specification see https://amwa-tv.github.io/nmos-authorization
+For an HTML rendering of this Specification see <https://amwa-tv.github.io/nmos-authorization>
 
 Readers are advised to be familiar with:
 

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -28,7 +28,7 @@ is not concerned with the security of the connection used to carry out authoriza
 interactions, for the authorization mechanisms described in this document to be effective the connection used MUST
 be encrypted.
 
-Implementation of [BCP-003-01] is a RECOMMENDED prerequisite to implementing this document.
+Implementation of [BCP-003-01][BCP-003-01] is a RECOMMENDED prerequisite to implementing this document.
 
 ## OAuth RFCs
 
@@ -154,9 +154,9 @@ usually used in machine-to-machine operations in which there is no concept of a 
 
 ## Future Considerations
 
-- The Device Authorization Grant ([RFC-8628]) may be added to this specification to enable resource-constrained
+- The Device Authorization Grant ([RFC 8628][RFC-8628]) may be added to this specification to enable resource-constrained
   devices to make use of a second device to enable user authorization.
-- The Client Credentials Grant may be permitted for machine-to-machine interactions within the NMOS [IS-06] endpoint
+- The Client Credentials Grant may be permitted for machine-to-machine interactions within the NMOS [IS-06][IS-06] endpoint
   registration process.
 - Use of the [Resource Indicators][oauth-resource-indicators] request parameters may be added to enable a client to
   explicitly signal to an

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -41,7 +41,7 @@ MUST NOT be prefixed by any additional path, including but not limited to 'x-nmo
 usual format of NMOS API's due to it following the syntax and semantics of ".well-known" endpoints defined in
 [RFC 5785][RFC-5785].
 
-*   **/.well-known/oauth-authorization-server[/<issuer_id_path>]** - This path MUST return a response matching the
+*   **/.well-known/oauth-authorization-server\[/<issuer_id_path>\]** - This path MUST return a response matching the
 requirements of OAuth 2.0 Authorization Server Metadata [RFC 8414][RFC-8414]. This MUST include the optional
 `jwks_uri`, `registration_endpoint` and `revocation_endpoint` parameters. The issuer identifier path
 (`/<issuer_id_path>`) is optional and defined in the [Discovery](./3.0.%20Discovery.md) Section.

--- a/docs/4.1. Behaviour - Authorization Servers.md
+++ b/docs/4.1. Behaviour - Authorization Servers.md
@@ -95,8 +95,6 @@ securely and maintained for at least one month.
 
 [RFC-2617]: https://tools.ietf.org/html/rfc2617 "HTTP Authentication: Basic and Digest Access Authentication"
 
-[RFC-4716]: https://tools.ietf.org/html/rfc4716 "The Secure Shell (SSH) Public Key File Format"
-
 [RFC-6749]: https://tools.ietf.org/html/rfc6749 "The OAuth 2.0 Authorization Framework"
 
 [RFC-7591]: https://tools.ietf.org/html/rfc7591 "OAuth 2.0 Dynamic Client Registration Protocol"

--- a/docs/4.2. Behaviour - Clients.md
+++ b/docs/4.2. Behaviour - Clients.md
@@ -124,6 +124,8 @@ Clients MUST be capable of handling early revocation of tokens, which will be si
 
 [RFC-7591]: https://tools.ietf.org/html/rfc7591 "OAuth 2.0 Dynamic Client Registration Protocol"
 
+[RFC-7636]: https://tools.ietf.org/html/rfc7636 "Proof Key for Code Exchange by OAuth Public Clients"
+
 [RFC-8252]: https://tools.ietf.org/html/rfc8252 "OAuth 2.0 for Native Apps"
 
 [RFC-8414]: https://tools.ietf.org/html/rfc8414 "OAuth 2.0 Authorization Server Metadata"

--- a/docs/4.3. Behaviour - Token Requests.md
+++ b/docs/4.3. Behaviour - Token Requests.md
@@ -92,8 +92,6 @@ uninstalling a given application.
 
 [RFC-7636]: https://tools.ietf.org/html/rfc7636 "Proof Key for Code Exchange by OAuth Public Clients"
 
-[RFC-8628]: https://tools.ietf.org/html/rfc8628 "OAuth 2.0 Device Authorization Grant"
-
 [oauth-security-topics]: https://datatracker.ietf.org/doc/draft-ietf-oauth-security-topics/ "OAuth 2.0 Security Best Current Practice 13"
 
 [oauth-browser-based-apps]: https://datatracker.ietf.org/doc/draft-ietf-oauth-browser-based-apps

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -121,12 +121,12 @@ also has "read" access to the specific API, a permission key of "read" MUST also
 object.
 
 Individual AMWA specifications MAY specify additional permissions keys specific to the individual API. These MUST be
-registered in the [AMWA NMOS Parameter Registers]. It is recommended that new permissions keys are only introduced
+registered in the [AMWA NMOS Parameter Registers][AMWA NMOS Parameter Registers]. It is recommended that new permissions keys are only introduced
 alongside a new version of a given AMWA NMOS API in order to minimise the risk of incompatibility.
 
 The `value` corresponding to each permission key is a JSON array containing URL path specifiers that the user is
 permitted to perform the specific request against. Wildcards are permitted in the path specifiers. The means by which
-wildcards may be used for pattern matching SHALL align with Section 2.13 of the [POSIX Standard]. It is RECOMMENDED
+wildcards may be used for pattern matching SHALL align with Section 2.13 of the [POSIX Standard][POSIX Standard]. It is RECOMMENDED
 that wildcards are used in place of URL parameters (such as specifying resource UUID's) to minimise token size.
 Specific URL parameters MAY be used in path specifiers if defining access to a small number of resources (such as
 a single node or device.)

--- a/docs/4.5. Behaviour - Resource Servers.md
+++ b/docs/4.5. Behaviour - Resource Servers.md
@@ -70,7 +70,7 @@ The value of the claims within the payload of the JWT must also be validated, in
 
 ## Interaction with other NMOS APIs
 
-Any further token validation requirements based on the specific NMOS API being accessed is highlighted in [BCP-03-02].
+Any further token validation requirements based on the specific NMOS API being accessed is highlighted in [BCP-003-02][BCP-003-02].
 
 ## Audit Requirements
 
@@ -85,4 +85,4 @@ such as secrets. Logs SHOULD be stored securely and maintained for at least one 
 
 [RFC-7515]: https://tools.ietf.org/html/rfc7515 "JSON Web Signature (JWS)"
 
-[BCP-03-02]: https://github.com/AMWA-TV/nmos-api-security/blob/v1.0-dev/best-practice-authorization.md "Best Practice Authorization"
+[BCP-003-02]: https://github.com/AMWA-TV/nmos-api-security/blob/v1.0-dev/best-practice-authorization.md "Best Practice Authorization"


### PR DESCRIPTION
Apart from the `list-item-indent` warnings which will be suppressed by https://github.com/AMWA-TV/nmos-lint-scripts/pull/1, this resolves all the issues noted in #15.

@dannymeloy, please would you check that I was right to delete the couple of definitions that were reported as `no-unused-definitions`, not that there were missing refs to those? Thanks!

