### PR TITLE
Limit use of wildcard character to asterisk `*`

### DIFF
--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -6,8 +6,7 @@
   "properties": {
     "iss": {
       "description": "The DNS name of the Authorization Server issuing the token",
-      "type": "string",
-      "format": "uri"
+      "type": "string"
     },
     "sub": {
       "description": "The unique identifier assigned to the end-user by the user authorization system",

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -132,8 +132,8 @@ specifiers.
 A '`*`' wildcard can be used to replace zero or more path characters, and may encompass multiple path segments (e.g.
 `/single/*` and `/single/senders/*/constraints` would both correspond to
 `/single/senders/ea388089-9ffb-4a81-b109-a19da845b3b6/constraints`). It is RECOMMENDED that wildcards are used in
-place of URL parameters (such as specifying resource UUID's) to minimise token size. Specific URL parameters MAY be
-used in path specifiers if defining access to a small number of resources (such as a single node or device.)
+place of resource identifiers, such as specifying resource UUIDs, to minimise token size. Specific identifiers MAY
+be used in path specifiers if defining access to a small number of resources (such as a single node or device.)
 
 For NMOS API URL's that follow the standard pattern of:
 

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -121,15 +121,20 @@ also has "read" access to the specific API, a permission key of "read" MUST also
 object.
 
 Individual AMWA specifications MAY specify additional permissions keys specific to the individual API. These MUST be
-registered in the [AMWA NMOS Parameter Registers][AMWA NMOS Parameter Registers]. It is recommended that new permissions keys are only introduced
-alongside a new version of a given AMWA NMOS API in order to minimise the risk of incompatibility.
+registered in the [AMWA NMOS Parameter Registers][AMWA NMOS Parameter Registers]. It is recommended that new
+permissions keys are only introduced alongside a new version of a given AMWA NMOS API in order to minimise the risk of
+incompatibility.
 
 The `value` corresponding to each permission key is a JSON array containing URL path specifiers that the user is
-permitted to perform the specific request against. Wildcards are permitted in the path specifiers. The means by which
-wildcards may be used for pattern matching SHALL align with Section 2.13 of the [POSIX Standard][POSIX Standard]. It is RECOMMENDED
-that wildcards are used in place of URL parameters (such as specifying resource UUID's) to minimise token size.
-Specific URL parameters MAY be used in path specifiers if defining access to a small number of resources (such as
-a single node or device.)
+permitted to perform the specific request against. The asterisk wildcard ('`*`') is permitted in the path
+specifiers. The means by which this wildcard may be used for pattern matching SHALL align with Section 2.13.1
+of the [POSIX Standard][POSIX Standard].
+
+A '`*`' wildcard can be used to replace zero or more path characters, and may encompass multiple path segments (e.g.
+`/single/*` and `/single/senders/*/constraints` would both correspond to
+`/single/senders/ea388089-9ffb-4a81-b109-a19da845b3b6/constraints`). It is RECOMMENDED that wildcards are used in
+place of URL parameters (such as specifying resource UUID's) to minimise token size. Specific URL parameters MAY be
+used in path specifiers if defining access to a small number of resources (such as a single node or device.)
 
 For NMOS API URL's that follow the standard pattern of:
 

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -127,8 +127,7 @@ incompatibility.
 
 The `value` corresponding to each permission key is a JSON array containing URL path specifiers that the user is
 permitted to perform the specific request against. The asterisk wildcard ('`*`') is permitted in the path
-specifiers. The means by which this wildcard may be used for pattern matching SHALL align with Section 2.13.1
-of the [POSIX Standard][POSIX Standard].
+specifiers.
 
 A '`*`' wildcard can be used to replace zero or more path characters, and may encompass multiple path segments (e.g.
 `/single/*` and `/single/senders/*/constraints` would both correspond to

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -237,5 +237,3 @@ invalid during transit. As such tokens SHOULD be valid for at least 30 seconds.
 [oauth-access-token-jwt]: https://datatracker.ietf.org/doc/draft-ietf-oauth-access-token-jwt/ "JSON Web Token Profile for OAuth 2.0 Access Tokens"
 
 [AMWA NMOS Parameter Registers]: https://github.com/AMWA-TV/nmos-parameter-registers
-
-[POSIX Standard]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html "Shell Command Language"

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -220,6 +220,8 @@ However, if access tokens are too short-lived, the number of refresh requests to
 tokens starts to become a significant overhead, and any latency involved in using a token may cause it to become
 invalid during transit. As such tokens SHOULD be valid for at least 30 seconds.
 
+<p align="center">30 seconds < TOKEN LIFETIME < 1 hour</p>
+
 
 [RFC-4592]: https://tools.ietf.org/html/rfc4592 "The Role of Wildcards in the Domain Name System"
 

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -132,7 +132,7 @@ specifiers.
 A '`*`' wildcard can be used to replace zero or more path characters, and may encompass multiple path segments (e.g.
 `/single/*` and `/single/senders/*/constraints` would both correspond to
 `/single/senders/ea388089-9ffb-4a81-b109-a19da845b3b6/constraints`). It is RECOMMENDED that wildcards are used in
-place of resource identifiers, such as specifying resource UUIDs, to minimise token size. Specific identifiers MAY
+place of NMOS resource identifiers, such as UUIDs, to minimise token size. Specific identifiers MAY
 be used in path specifiers if defining access to a small number of resources (such as a single node or device.)
 
 For NMOS API URL's that follow the standard pattern of:

--- a/examples/register-client-post-400.json
+++ b/examples/register-client-post-400.json
@@ -1,3 +1,0 @@
-{
-    "error": "invalid_redirect_uri"
-}

--- a/examples/register-client-post-400.json
+++ b/examples/register-client-post-400.json
@@ -1,0 +1,3 @@
+{
+    "error": "invalid_redirect_uri"
+}


### PR DESCRIPTION
- Also removes `uri` limitation on `issuer` claim in line with RFC7519]: The "iss" value is a case-sensitive string containing a StringOrURI value.
- Emphasized range of token lifetime due to concerns about 30 second expiry 