### PR TITLE
removing "client_secret_expires_at" from required

### DIFF
--- a/APIs/schemas/register_client_response.json
+++ b/APIs/schemas/register_client_response.json
@@ -99,5 +99,5 @@
       "type": "string"
     }
   },
-  "required": ["client_id", "client_secret_expires_at"]
+  "required": ["client_id"]
 }


### PR DESCRIPTION
As per the [RFC](https://tools.ietf.org/html/rfc7591#section-3.2.1) 
> client_secret_expires_at:       REQUIRED if "client_secret" is issued.

And 

> client_secret:    OPTIONAL.

RFC is confusing 😄 