### PR TITLE
x5c should be an array of string rather than just a string

### DIFF
--- a/APIs/schemas/jwks_response.json
+++ b/APIs/schemas/jwks_response.json
@@ -31,7 +31,10 @@
             "format": "uri"
           },
           "x5c": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "x5t": {
             "type": "string"


### PR DESCRIPTION
x5c should be an array of string rather than just a string, as shown in RFC7517
see https://tools.ietf.org/html/rfc7517#section-4.7