### PR TITLE
docs: add explicit scope parameter for dynamic registration

### DIFF
--- a/docs/4.2. Behaviour - Clients.md
+++ b/docs/4.2. Behaviour - Clients.md
@@ -20,7 +20,8 @@ containing the required details).
 
 Clients are RECOMMENDED to provide for the OAuth 2.0 Dynamic Client Registration Protocol [RFC 7591][RFC-7591] to allow
 for zero-configuration setup. NMOS Nodes SHOULD be capable of registering dynamically in order to limit the
-configuration associated with large numbers of Nodes coming online simultaneously.
+configuration associated with large numbers of Nodes coming online simultaneously. Clients MUST include a populated
+`scope` parameter when performing dynamic registrations.
 
 Clients that do not register with an explicit `token_endpoint_auth_method` parameter will be registered as a
 Confidential Client and issued with a client secret. Public clients MUST specify a value of "none" for this parameter

--- a/examples/register-client-post-201.json
+++ b/examples/register-client-post-201.json
@@ -2,5 +2,6 @@
   "client_id": "s6BhdRkqt3",
   "client_secret": "cf136dc3c1fc93f31185e5885805d",
   "client_id_issued_at": 2893256800,
-  "client_secret_expires_at": 2893276800
+  "client_secret_expires_at": 2893276800,
+  "scope": "registration connection"
 }

--- a/examples/register-client-post-request.json
+++ b/examples/register-client-post-request.json
@@ -8,5 +8,6 @@
   "token_endpoint_auth_method": "client_secret_basic",
   "logo_uri": "https://client.example.org/logo.png",
   "jwks_uri": "https://client.example.org/my_public_keys.jwks",
-  "example_extension_parameter": "example_value"
+  "example_extension_parameter": "example_value",
+  "scope": "registration connection"
  }


### PR DESCRIPTION
Resolves #28 

Adds an explicit note that clients are expected to specify their required scopes. Authorization servers cannot be guaranteed to do this on their behalf.