### PR TITLE
jwks: don't mandate kid format given lack of commercial support

### DIFF
--- a/APIs/schemas/jwks_response.json
+++ b/APIs/schemas/jwks_response.json
@@ -23,8 +23,7 @@
             "type": "string"
           },
           "kid": {
-            "type": "string",
-            "pattern": "^(x-nmos-[0-9]+)$"
+            "type": "string"
           },
           "x5u": {
             "type": "string",

--- a/docs/4.1. Behaviour - Authorization Servers.md
+++ b/docs/4.1. Behaviour - Authorization Servers.md
@@ -14,13 +14,6 @@ The format of the keys MUST be the JSON Web Key (JWK) format described in Sectio
 MUST form a JSON Web Key Set (JWKS) described in Section 5 of [RFC 8414][RFC-8414]. Authorization Servers MAY
 present more than one key within a JSON Web Key Set, with each key being an entry in the "keys" array.
 
-Any JSON Web Keys used to sign tokens for NMOS APIs MUST use a `kid` (Key ID) matching the following regular
-expression. The trailing integer in this expression is intended to be an integer timestamp matching the issue time of
-the key to facilitate key rotation.
-```
-^x-nmos-\d+$
-```
-
 ### Changing Keys
 
 When transitioning to a new public/private key pair used for signing tokens an Authorization Server SHOULD provide

--- a/docs/4.5. Behaviour - Resource Servers.md
+++ b/docs/4.5. Behaviour - Resource Servers.md
@@ -14,9 +14,7 @@ Resource Server is unable to contact an Authorization Server, the Resource Serve
 keys remain valid until it is able to re-establish a connection to an Authorization Server.
 
 Resource Servers SHOULD attempt to verify tokens against all keys presented at the Authorization Server's public key
-endpoint that match the specified NMOS `kid` format, outlined in
-[Authorization Servers](./4.1.%20Behaviour%20-%20Authorization%20Servers.md). All valid JWK's SHOULD be
-tried until the token is verified or until no keys are left.
+endpoint. All valid JWK's SHOULD be tried until the token is verified or until no keys are left.
 
 If the Resource Server fails to verify all public keys available, it MUST reject the token.
 


### PR DESCRIPTION
Resolves #27 

This ensures that we remain compatible with commercial auth servers which don't necessarily allow you to specify custom 'kid' values.