### PR TITLE
Remove enums from schemas. "token_type" field treated as case-insensitive

### DIFF
--- a/APIs/schemas/register_client_request.json
+++ b/APIs/schemas/register_client_request.json
@@ -20,16 +20,14 @@
       "description": "Array of OAuth 2.0 grant type strings that the client can use at the token endpoint",
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": ["authorization_code", "implicit", "password", "client_credentials", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer" ]
+        "type": "string"
       }
     },
     "response_types": {
       "description": "Array of the OAuth 2.0 response type strings that the client can use at the authorization endpoint",
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": [ "code", "token" ]
+        "type": "string"
       }
     },
     "client_name": {

--- a/APIs/schemas/register_client_response.json
+++ b/APIs/schemas/register_client_response.json
@@ -37,8 +37,7 @@
       "description": "Array of OAuth 2.0 grant type strings that the client can use at the token endpoint",
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": ["authorization_code", "implicit", "password", "client_credentials", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer" ]
+        "type": "string"
       },
       "default": [ "authorization_code" ]
     },
@@ -46,8 +45,7 @@
       "description": "Array of the OAuth 2.0 response type strings that the client can use at the authorization endpoint",
       "type": "array",
       "items": {
-        "type": "string",
-        "enum": [ "code", "token" ]
+        "type": "string"
       },
       "default": [ "code" ]
     },

--- a/APIs/schemas/token_response.json
+++ b/APIs/schemas/token_response.json
@@ -22,10 +22,7 @@
     },
     "token_type": {
       "description": "The type of the Token issued",
-      "type": "string",
-      "enum": [
-        "Bearer"
-      ]
+      "type": "string"
     }
   },
   "required": ["access_token", "expires_in", "token_type"]

--- a/docs/4.3. Behaviour - Token Requests.md
+++ b/docs/4.3. Behaviour - Token Requests.md
@@ -52,7 +52,9 @@ For Public Clients, the additional parameter of `code_verifier` is added to the 
 [RFC 7636][RFC-7636] to prevent authorization code hijacking.
 
 Successful access token responses SHALL be serviced by the Authorization Server as defined in [RFC 6749][RFC-6749]
-Section 5.1. Additionally the `expires_in` and `refresh_token` fields MUST be included in the response.
+Section 5.1. Additionally the `expires_in` and `refresh_token` fields MUST be included in the response. The
+`token_type` field value MUST be treated as case-insensitive, in order to accommodate values such as "Bearer" and
+"bearer".
 
 ## Refresh Tokens
 


### PR DESCRIPTION
This PR removes the enumerations associated with the "grant_type" and "response_type" fields due to the new grant types ("hybrid", etc) and response types ("id_token", "none", etc.) )introduced in the OpenID Connect protocol, as well custom grant types also  being defined. 

It also states that the value of the "token_type" field should be case-insensitive, due to some OTS Auth Servers producing a value of "bearer" instead of "Bearer"