### PR TITLE
token 'aud' claim to accept a single string or array of strings

### DIFF
--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -14,10 +14,17 @@
     },
     "aud": {
       "description": "A JSON array of case-sensitive strings, each containing a StringOrURI value that identifies the recipients that the JWT is intended for",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+          "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "exp": {
       "description": "The UTC time at which the token expires",

--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -14,7 +14,7 @@
     },
     "aud": {
       "description": "A JSON array of case-sensitive strings, each containing a StringOrURI value that identifies the recipients that the JWT is intended for",
-      "anyOf": [
+      "oneOf": [
         {
           "type": "array",
           "items": {


### PR DESCRIPTION
In the general case, the "aud" value is an array of case-sensitive strings, each containing a StringOrURI value.  In the special case when the JWT has one audience, the "aud" value MAY be a single case-sensitive string containing a StringOrURI value.

see RFC7519 https://tools.ietf.org/html/rfc7519#section-4.1.3