### PR TITLE
tokens: change x-nmos-api claim to x-nmos-*

### DIFF
--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -34,34 +34,30 @@
     "scope": {
       "description": "A string containing a space-separated list of scopes associated with the token",
       "type": "string"
-    },
-    "x-nmos-api": {
-      "description": "An object containing the access permissions of the user for the listed NMOS APIs",
+    }
+  },
+  "patternProperties": {
+    "^x-nmos-[a-z]+$": {
+      "description": "An object containing the access permissions of the user for the NMOS API identified by this attribute's name",
       "type": "object",
       "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z_-]+$": {
-          "type": "object",
-          "minProperties": 1,
-          "properties": {
-            "read": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1
-            },
-            "write": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1
-            }
-          }
+      "properties": {
+        "read": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "write": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         }
       }
     }
   },
-  "required": ["iss", "sub", "aud", "exp", "client_id", "x-nmos-api"]
+  "required": ["iss", "sub", "aud", "exp", "client_id"]
 }

--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -41,6 +41,7 @@
       "description": "An object containing the access permissions of the user for the NMOS API identified by this attribute's name",
       "type": "object",
       "additionalProperties": false,
+      "minProperties": 1,
       "properties": {
         "read": {
           "type": "array",

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -90,24 +90,24 @@ in Section 3.3 of [RFC6749][RFC-6749].
 
 The value of each scope corresponds to the namespace identifier for a given NMOS
 API (e.g. "registration", "query", etc.) to which the user is requesting access and determines how the private
-`x-nmos-api` claim, detailed below, is populated.
+`x-nmos-*` claims, detailed below, are populated.
 
 ## Private Claims
 
-[RFC 7519][RFC-7519] allows for "private claims". The following claim is used to identify the API specification a given
+[RFC 7519][RFC-7519] allows for "private claims". The following claims are used to identify the API specification(s) a given
 token is used for.
 
-### x-nmos-api
+### x-nmos-*
 _Contains information particular to the NMOS API the token is intended for_
 
-The `x-nmos-api` claim MUST be included in the token. The value of the claim is a JSON object, the contents of which
-are `key:value` pairs, with the `key` identifying an individual AMWA NMOS API using the namespace identifier found in
-the URL for that given API (e.g. "registration", "query", etc.), and the `value` being a JSON object indicating access
-permissions for that API. An empty `x-nmos-api` object MUST indicate no access to any of the APIs. A missing API key
-MUST indicate no access to that specific API.
+One or more `x-nmos-*` claims MUST be included in the token. The claim name begins `x-nmos-` followed by the namespace
+identifier found in the URL for that given API (e.g. "registration", "query", etc.).
+
+The value of the claim is a JSON object, indicating access permissions for that API. An empty or missing `x-nmos-*`
+object indicates that no access is permitted to the namespace-identified API.
 
 #### The Access Permissions Object
-The value of each NMOS API key is the access permissions object for the given user for that specific API. The access
+The value of each `x-nmos-*` claim is the access permissions object for the given user for that specific API. The access
 permission object consists of `key:value` pairs in which the `key` denotes a specific permission. General permissions
 include:
 *   **write** - ability to insert a new, or edit an existing, resource. This takes the form of *POST*, *PUT*,
@@ -116,8 +116,8 @@ include:
     verbs.
 
 If a permission has not been granted to a specific user, the permission key MUST be omitted, to minimise the
-token size. If no permissions are given for a specific API, the API key MUST be removed from the `x-nmos-api` claim,
-to ensure token size is minimised.
+token size. If no permissions are given for a specific API, the `x-nmos-*` claim relating to that API key MUST be
+removed to ensure token size is minimised.
 
 If a permission of "write" is given in the access permission object, and the intention is that the given user
 also has "read" access to the specific API, a permission key of "read" MUST also be present in the access permissions
@@ -144,33 +144,31 @@ For NMOS API URL's that follow the standard pattern of:
 
 all path specifiers MUST start _after_ the API version and its trailing slash. For example, authorizing a user to read
 all _single resources_ and modify the configuration of all  _single senders_ at a Connection Management interface would
-result in an access permissions object of:
+result in a claim of:
 
 ```JSON
-"connection": {
+"x-nmos-connection": {
   "read": ["single/*"],
   "write": ["single/senders/*"]
 }
 ```
 
-#### Example `x-nmos-api` Claim
-An example of a `x-nmos-api` claim is shown below. This would permit querying an IS-04 Registry, and modifying
+#### Example `x-nmos-*` Claims
+Examples of `x-nmos-*` claims are shown below. This would permit querying an IS-04 Registry, and modifying
 _single_ connections via an IS-05 connection management interface, but would not permit the user to register a resource
 with an IS-04 Registry.
 
 ```json
-"x-nmos-api": {
-  "registration": {
-    "read": ["*"]
-  },
-  "query": {
-    "read": ["*"],
-    "write": ["subscriptions/*"]
-  },
-  "connection": {
-    "read": ["*"],
-    "write": ["single/*"]
-  }
+"x-nmos-registration": {
+  "read": ["*"]
+},
+"x-nmos-query": {
+  "read": ["*"],
+  "write": ["subscriptions/*"]
+},
+"x-nmos-connection": {
+  "read": ["*"],
+  "write": ["single/*"]
 }
 ```
 
@@ -195,18 +193,16 @@ claims, and ensure that enough space is available in the header for both the tok
   "exp": 1548783060,
   "scope": "registration query connection",
   "client_id": "hopy0dNRPNTiGJDqPfqYwGmw",
-  "x-nmos-api": {
-    "registration": {
-      "read": ["*"]
-    },
-    "query": {
-      "read": ["*"],
-      "write": ["subscriptions/*"]
-    },
-    "connection": {
-      "read": ["*"],
-      "write": ["single/*"]
-    }
+  "x-nmos-registration": {
+    "read": ["*"]
+  },
+  "x-nmos-query": {
+    "read": ["*"],
+    "write": ["subscriptions/*"]
+  },
+  "x-nmos-connection": {
+    "read": ["*"],
+    "write": ["single/*"]
   }
 }
 ```

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -103,8 +103,8 @@ _Contains information particular to the NMOS API the token is intended for_
 One or more `x-nmos-*` claims MUST be included in the token. The claim name begins `x-nmos-` followed by the namespace
 identifier found in the URL for that given API (e.g. "registration", "query", etc.).
 
-The value of the claim is a JSON object, indicating access permissions for that API. An empty or missing `x-nmos-*`
-object indicates that no access is permitted to the namespace-identified API.
+The value of the claim is a JSON object, indicating access permissions for that API. An omitted `x-nmos-*` object indicates
+that no access is permitted to the namespace-identified API.
 
 #### The Access Permissions Object
 The value of each `x-nmos-*` claim is the access permissions object for the given user for that specific API. The access

--- a/docs/4.5. Behaviour - Resource Servers.md
+++ b/docs/4.5. Behaviour - Resource Servers.md
@@ -63,7 +63,7 @@ The value of the claims within the payload of the JWT must also be validated, in
 *   the `iat` claim is greater than the current UTC time.
 *   the `exp` claim is less than the current UTC time.
 *   the Resource Server does not identify itself with the `aud` claim
-*   the request is not permitted by the value of the `x-nmos-api` claim, in line with the method outlined in
+*   the request is not permitted by the values of the `x-nmos-*` claims, in line with the method outlined in
 [Tokens](./4.4.%20Behaviour%20-%20Access%20Tokens.md).
 
 ## Interaction with other NMOS APIs

--- a/examples/access_token.json
+++ b/examples/access_token.json
@@ -6,17 +6,15 @@
   "exp": 1548783060,
   "scope": "registration query connection",
   "client_id": "hopy0dNRPNTiGJDqPfqYwGmw",
-  "x-nmos-api": {
-    "registration": {
-      "read": ["*"]
-    },
-    "query": {
-      "read": ["*"],
-      "write": ["subscriptions/*"]
-    },
-    "connection": {
-      "read": ["*"],
-      "write": ["single/*"]
-    }
+  "x-nmos-registration": {
+    "read": ["*"]
+  },
+  "x-nmos-query": {
+    "read": ["*"],
+    "write": ["subscriptions/*"]
+  },
+  "x-nmos-connection": {
+    "read": ["*"],
+    "write": ["single/*"]
   }
 }


### PR DESCRIPTION
Resolves #26 

Ensures a 1:1 mapping between each scope and the claim object it generates.