### PR TITLE
client_id: make optional given some auth servers don't support it

### DIFF
--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -67,5 +67,5 @@
       }
     }
   },
-  "required": ["iss", "sub", "aud", "exp", "client_id"]
+  "required": ["iss", "sub", "aud", "exp"]
 }

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -75,8 +75,7 @@ SHALL issue a token with an `iat` claim that is equal to the UTC time at which t
 ### client_id
 _Client ID that requested the token_
 
-The `client_id` claim SHOULD be included in the token, as per Section 2.2 of the draft RFC
-[Profile for OAuth 2.0 Access Tokens][oauth-access-token-jwt]. This claim corresponds with the client identifier of the
+The `client_id` claim SHOULD be included in the token. This claim corresponds with the client identifier of the
 OAuth 2.0 client that requested the token. The value of this claim MUST exactly match the full client identifier to
 which the token was granted.
 

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -75,7 +75,7 @@ SHALL issue a token with an `iat` claim that is equal to the UTC time at which t
 ### client_id
 _Client ID that requested the token_
 
-The `client_id` claim MUST be included in the token, as per Section 2.2 of the draft RFC
+The `client_id` claim SHOULD be included in the token, as per Section 2.2 of the draft RFC
 [Profile for OAuth 2.0 Access Tokens][oauth-access-token-jwt]. This claim corresponds with the client identifier of the
 OAuth 2.0 client that requested the token. The value of this claim MUST exactly match the full client identifier to
 which the token was granted.


### PR DESCRIPTION
Resolves #34 

It doesn't currently appear to be possible to enable this in keycloak, so to maximise compatibility this reverts the requirement to a SHOULD. Note that this was partially mandated because it eases the capability to audit which clients have been making requests.