### PR TITLE
Link BCP-003-01 to https://github.com/AMWA-TV/nmos-secure-communication

### DIFF
--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -200,6 +200,6 @@ usually used in machine-to-machine operations in which there is no concept of a 
 
 [oauth-security-topics]: https://datatracker.ietf.org/doc/draft-ietf-oauth-security-topics/ "OAuth 2.0 Security Best Current Practice"
 
-[BCP-003-01]: https://github.com/AMWA-TV/nmos-api-security/blob/v1.0-dev/best-practice-secure-comms.md
+[BCP-003-01]: https://github.com/AMWA-TV/nmos-secure-communication "AMWA BCP-003-01 Secure Communication in NMOS Systems"
 
 [IS-06]: https://amwa-tv.github.io/nmos-network-control/ "AMWA IS-06 NMOS Network Control Specification"


### PR DESCRIPTION
Or should the link to BCP-003-01 be https://amwa-tv.github.io/nmos-secure-communication/ ?