### PR TITLE
docs: require resource server token errors to have a JSON body

### DIFF
--- a/APIs/schemas/resource_error_response.json
+++ b/APIs/schemas/resource_error_response.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Resource Server Error Response",
+  "description": "Describes the resource server's OAuth error response",
+  "type": "object",
+  "minItems": 1,
+  "properties": {
+    "error": {
+      "description": "Error Type",
+      "type": "string",
+      "enum": [
+        "invalid_request",
+        "invalid_token",
+        "insufficient_scope"
+      ]
+    },
+    "error_description": {
+      "description": "Human-readable ASCII text providing additional information",
+      "type": "string"
+    },
+    "error_uri": {
+      "description": "A URI identifying a human-readable web page with information about the error",
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "required": [
+    "error"
+  ]
+}

--- a/docs/4.5. Behaviour - Resource Servers.md
+++ b/docs/4.5. Behaviour - Resource Servers.md
@@ -28,7 +28,8 @@ When a protected resource receives a token it MUST validate the signature and cl
 If a protected resource request does not include authentication credentials or does not contain an access token
 that enables access to the protected resource, the resource server MUST reject the request with the appropriate
 HTTP error code and include the HTTP `WWW-Authenticate` response header field using the auth-scheme value "Bearer",
-as per Section 3 of [RFC 6750][RFC-6750].
+as per Section 3 of [RFC 6750][RFC-6750]. The response body MUST also match the resource server
+[error schema](../APIs/schemas/resource_error_response.json).
 
 For example:
 *   A request without authentication or one including an expired access token will receive a 401 (Unauthorized) response.


### PR DESCRIPTION
Resolves #64

RFC6750 only requires error data to be returned in the headers, presumably because it may be used against non-JSON resources. As our APIs always use JSON, it seems reasonable to expect resource servers to respond with JSON in a similar way to the authorization server. If others agree, this adds a suitable schema and reference in the docs.