### PR TITLE
is10: document implicit permissions for API base paths

### DIFF
--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -51,20 +51,21 @@
     "^x-nmos-[a-z]+$": {
       "description": "An object containing the access permissions of the user for the NMOS API identified by this attribute's name",
       "type": "object",
-      "additionalProperties": false,
       "minProperties": 1,
       "properties": {
         "read": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^.+$"
           },
           "minItems": 1
         },
         "write": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^.+$"
           },
           "minItems": 1
         }

--- a/APIs/schemas/token_schema.json
+++ b/APIs/schemas/token_schema.json
@@ -57,7 +57,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^.+$"
+            "minLength": 1
           },
           "minItems": 1
         },
@@ -65,7 +65,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^.+$"
+            "minLength": 1
           },
           "minItems": 1
         }

--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -100,6 +100,9 @@ The value of each scope corresponds to the namespace identifier for a given NMOS
 API (e.g. "registration", "query", etc.) to which the user is requesting access and determines how the private
 `x-nmos-*` claims, detailed below, are populated.
 
+Presence of a `scope` matching an NMOS API grants implicit read only access to some API base paths as specified in
+[Resource Servers](4.5.%20Behaviour%20-%20Resource%20Servers.md).
+
 ## Private Claims
 
 [RFC 7519][RFC-7519] allows for "private claims". The following claims are used to identify the API specification(s) a given
@@ -108,11 +111,15 @@ token is used for.
 ### x-nmos-*
 _Contains information particular to the NMOS API the token is intended for_
 
-One or more `x-nmos-*` claims MUST be included in the token. The claim name begins `x-nmos-` followed by the namespace
+One or more `x-nmos-*` claims SHOULD be included in the token. The claim name begins `x-nmos-` followed by the namespace
 identifier found in the URL for that given API (e.g. "registration", "query", etc.).
 
-The value of the claim is a JSON object, indicating access permissions for that API. An omitted `x-nmos-*` object indicates
-that no access is permitted to the namespace-identified API.
+Presence of an `x-nmos-*` claim matching an NMOS API grants implicit read only access to some API base paths as
+specified in [Resource Servers](4.5.%20Behaviour%20-%20Resource%20Servers.md).
+
+The value of the claim is a JSON object, indicating access permissions for the API. An omitted `x-nmos-*` object
+indicates that no access is permitted to the namespace-identified API beyond what may be granted by the presence of
+a matching `scope`.
 
 #### The Access Permissions Object
 The value of each `x-nmos-*` claim is the access permissions object for the given user for that specific API. The access
@@ -147,8 +154,9 @@ permission (e.g. `single*` or `single/senders/*/constraints` would both match wi
 wildcard is used in place of NMOS resource identifiers, such as UUIDs, to minimise token size. Specific identifiers MAY
 be used in path specifiers if defining access to a small number of resources (such as a single node or device.)
 
-Resource Servers MUST apply [URL Normalization][URL Normalization] to request URLs in order to remove '`..`' path segments, which could otherwise introduce
-vulnerabilities. For example, the path `/x-nmos/connection/v1.1/single/../bulk` MUST NOT be permitted by `single/*` path permission.
+Resource Servers MUST apply [URL Normalization][URL Normalization] to request URLs in order to remove '`..`' path
+segments, which could otherwise introduce vulnerabilities. For example, the path
+`/x-nmos/connection/v1.1/single/../bulk` MUST NOT be permitted by `single/*` path permission.
 
 For NMOS API URL's that follow the standard pattern of:
 

--- a/docs/4.5. Behaviour - Resource Servers.md
+++ b/docs/4.5. Behaviour - Resource Servers.md
@@ -67,8 +67,19 @@ The value of the claims within the payload of the JWT must also be validated, in
 *   the `iat` claim is greater than the current UTC time.
 *   the `exp` claim is less than the current UTC time.
 *   the Resource Server does not identify itself with the `aud` claim
-*   the request is not permitted by the values of the `x-nmos-*` claims, in line with the method outlined in
-[Tokens](4.4.%20Behaviour%20-%20Access%20Tokens.md).
+
+### Path Validation
+
+Resource Servers MUST verify that the URL path component requested matches one which is permitted by the token, ignoring any URL query parameters. The
+following rules MUST be followed when confirming a match.
+
+| Path | Requirements |
+| ---- | ------------ |
+| `/`  | Always allow 'read' permission with no authorization checks. This includes implicit permission to this path with or without a trailing slash |
+| `/x-nmos` | Always allow 'read' permission with no authorization checks. This includes implicit permission to this path with or without a trailing slash |
+| `/x-nmos/<api name>` | The token MUST include either an `x-nmos-*` claim matching the API name, a `scope` matching the API name or both in order to obtain 'read' permission. This includes implicit permission to this path with or without a trailing slash |
+| `/x-nmos/<api name>/<api version>` | The token MUST include either an `x-nmos-*` claim matching the API name, a `scope` matching the API name or both in order to obtain 'read' permission. This includes implicit permission to this path with or without a trailing slash |
+| `/x-nmos/<api name>/<api version>/<path>` | The token MUST include an `x-nmos-*` claim matching the API name and the path, in line with the method outlined in [Tokens](4.4.%20Behaviour%20-%20Access%20Tokens.md) |
 
 ## Interaction with other NMOS APIs
 


### PR DESCRIPTION
Resolves #66 

Note that 'additionalProperties: false' is removed from the token schema as this goes against the spec line "Individual AMWA specifications MAY specify additional permissions keys specific to the individual API"