### PR TITLE
Fix typo ./well-known to /.well-known 

### DIFF
--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -38,13 +38,14 @@ https://<ip address or hostname>:<port>/x-nmos/auth/<api version>/
 
 The Authorization Server MUST implement an endpoint at the following path. This path immediately follows the port and
 MUST NOT be prefixed by any additional path, including but not limited to 'x-nmos'. This endpoint cannot follow the
-usual format of NMOS API's due to it following the syntax and semantics of ".well-known" endpoints defined in
+usual format of NMOS APIs due to it following the syntax and semantics of ".well-known" endpoints defined in
 [RFC 5785][RFC-5785].
 
-*   **/.well-known/oauth-authorization-server\[/<issuer_id_path>\]** - This path MUST return a response matching the
+*   **/.well-known/oauth-authorization-server\[/<api_selector>\]** - This path MUST return a response matching the
 requirements of OAuth 2.0 Authorization Server Metadata [RFC 8414][RFC-8414]. This MUST include the optional
-`jwks_uri`, `registration_endpoint` and `revocation_endpoint` parameters. The issuer identifier path
-(`/<issuer_id_path>`) is optional and defined in the [Discovery](3.0.%20Discovery.md) Section.
+`jwks_uri`, `registration_endpoint` and `revocation_endpoint` parameters. The optional `/`-prefixed `api_selector`
+is defined in the [Discovery](3.0.%20Discovery.md) Section as the "path component of the issuer identifier", that is
+`x-nmos/auth/<api version>` in the example above.
 
 ### Endpoints
 

--- a/docs/3.0. Discovery.md
+++ b/docs/3.0. Discovery.md
@@ -30,7 +30,7 @@ discovery, as described in [RFC 6763][RFC-6763].
 
 ### Authorization Server Metadata Endpoint
 
-The Server Metadata endpoint is described in [RFC 8414][RFC-8414]. The "/.well-known" URI suffix of "oauth-
+The Server Metadata endpoint is described in [RFC 8414][RFC-8414]. The ".well-known" URI suffix of "oauth-
 authorization-server" MUST be used to identify the Authorization Server metadata endpoint. The value of the
 Authorization Server metadata URL should take the form:
 
@@ -38,9 +38,9 @@ Authorization Server metadata URL should take the form:
 <api_proto>://<hostname>:<port>/.well-known/oauth-authorization-server[/<api_selector>]
 ```
 
-Where `./well-known/oauth-authorization-server` forms the "well-known URI suffix" and the optional `api_selector` forms
-the "issuer identifier path", with the latter enabling support for multiple issuers per host. Placeholders are
-described in [DNS-SD TXT Records](#dns-sd-txt-records) below.
+Where `/.well-known/oauth-authorization-server` forms the "well-known URI string" and the optional `/`-prefixed
+`api_selector` is the "path component of the issuer identifier", with the latter enabling support for multiple
+issuers per host. Placeholders are described in [DNS-SD TXT Records](#dns-sd-txt-records) below.
 
 ### Use with TLS
 
@@ -78,18 +78,19 @@ indicator to the client of what versions of this specification the authorization
 The DNS-SD advertisement MUST include a TXT record with key `pri` and an integer value. Servers MAY additionally
 present a matching priority via the DNS-SD SRV record `priority` and `weight` as defined in [RFC 2782][RFC-2782]. The
 TXT record should be used in favour of the SRV priority and weight where these values differ, in order to overcome
-issues in the Bonjour and Avahi implementations. Values 0 to 99 correspond to an active NMOS Authorization Server API
+issues in the Bonjour and Avahi implementations. Values 0 to 99 correspond to an active NMOS Authorization API
 (zero being the highest priority). Values 100+ are reserved for development work to avoid colliding with a live system.
 
 #### api_selector
 
 The DNS_SD advertisement MAY include a TXT record of name `api_selector`. The value of this TXT record is a string
-relating to the "issuer identifier path", as described in Section 3.1 of [RFC 8414][RFC-8414], and is appended to the
-server metadata URL. If this record is omitted or is equal to an empty string, the value of this record MUST be
-omitted from the path specifier for the `well-known` endpoint.
+corresponding to the "path component of the issuer identifier", as described in Section 3.1 of [RFC 8414][RFC-8414],
+with the initial '/' omitted.
+It is used as described in [Authorization Server Metadata Endpoint](#authorization-server-metadata-endpoint) above.
+If this record is omitted or is equal to an empty string, the ".well-known" URI does not include a path component.
 
-The `api_selector` TXT record value MAY be equal to the NMOS API path prefix used by the advertised host (for example
-`x-nmos/auth/v1.0`).
+For example, when the base of the Authorization API on the advertised host is found at `/x-nmos/auth/v1.0/`,
+the `api_selector` TXT record value MUST be equal to `x-nmos/auth/v1.0`.
 
 ## Implementation Notes
 


### PR DESCRIPTION
Try to make explanation and references to terms in RFC 8414 more consistent in 2.0. APIs and 3.0. Discovery docs.