### PR TITLE
Fix typo in link to RFC document

### DIFF
--- a/docs/4.2. Behaviour - Clients.md
+++ b/docs/4.2. Behaviour - Clients.md
@@ -150,7 +150,7 @@ Further details on when Resource Servers will respond with particular codes is c
 
 [RFC-6750]: https://tools.ietf.org/html/rfc6750 "The OAuth 2.0 Authorization Framework: Bearer Token Usage"
 
-[RFC-7523]: https://tools.ietf.org/html/rfc7591 "JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants"
+[RFC-7523]: https://tools.ietf.org/html/rfc7523 "JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants"
 
 [RFC-7591]: https://tools.ietf.org/html/rfc7591 "OAuth 2.0 Dynamic Client Registration Protocol"
 


### PR DESCRIPTION
Resolves #96 