### PR TITLE
Maintenance of logs is too onerous a requirement for low-storage Resource Servers

### DIFF
--- a/docs/4.1. Behaviour - Authorization Servers.md
+++ b/docs/4.1. Behaviour - Authorization Servers.md
@@ -90,10 +90,9 @@ requesting Access Tokens and refreshing and revoking tokens.
 
 ## Audit Requirements
 
-Authorization Servers MUST maintain a log of each authorization and client registration which is performed, including
-initial token generation and token refreshes. Logs MUST be stored alongside an accurate timestamp and an identifier for
-the user who authorized the action. Logs MUST NOT contain sensitive information such as secrets. Logs SHOULD be stored
-securely and maintained for at least one month.
+Authorization Servers MUST securely provide a log of each authorization and client registration which is performed,
+including initial token generation and token refreshes. Logs MUST include an accurate timestamp and an identifier for
+the user who authorized the action. Logs MUST NOT contain sensitive information such as secrets.
 
 
 [RFC-2617]: https://tools.ietf.org/html/rfc2617 "HTTP Authentication: Basic and Digest Access Authentication"

--- a/docs/4.5. Behaviour - Resource Servers.md
+++ b/docs/4.5. Behaviour - Resource Servers.md
@@ -105,9 +105,9 @@ Any further token validation requirements based on the specific NMOS API being a
 
 ## Audit Requirements
 
-Resource Servers MUST maintain a log of each request which they authorize or reject. Logs MUST be stored alongside an
+Resource Servers MUST securely provide a log of each request which they authorize or reject. Logs MUST include an
 accurate timestamp and details of the token passed to them in the request. Logs MUST NOT contain sensitive information
-such as secrets. Logs SHOULD be stored securely and maintained for at least one month.
+such as secrets.
 
 
 [RFC-6455]: https://tools.ietf.org/html/rfc6455 "The WebSocket Protocol"


### PR DESCRIPTION
Tweak the Audit Requirements so that Resource Servers and Authorization Servers must securely _provide_ logs in order that systems can implement storage policies according to their requirements. Provision of logs may involve local storage on the resource server or e.g. transmission of logs securely to another server/service.