### PR TITLE
Added "nbf" claim to the Access Token registered claims description

### DIFF
--- a/docs/4.4. Behaviour - Access Tokens.md
+++ b/docs/4.4. Behaviour - Access Tokens.md
@@ -106,6 +106,14 @@ API (e.g. "registration", "query", etc.) to which the user is requesting access 
 Presence of a `scope` matching an NMOS API grants implicit read only access to some API base paths as specified in
 [Resource Servers](4.5.%20Behaviour%20-%20Resource%20Servers.md).
 
+### nbf
+_Not before time_
+
+The `nbf` (not before) claim MAY be included in the token.  The "nbf" (not before) claim identifies the time before 
+which the JWT MUST NOT be accepted for processing.  The processing of the "nbf" claim requires that the current 
+date/time MUST be after or equal to the not-before date/time listed in the "nbf" claim. 
+This is defined in  [RFC 7519](https://tools.ietf.org/html/rfc7519 "JSON Web Token (JWT)").
+
 ## Private Claims
 
 [RFC 7519][RFC-7519] allows for "private claims". The following claims are used to identify the API specification(s) a given


### PR DESCRIPTION
The description of this claim was included in the Implementation Guide as it is used by some Authentication Servers (for example Keycloak).  However, this is probably better placed in the specification itself.